### PR TITLE
Fix response handling with empty body

### DIFF
--- a/lib/calendlyr/resource.rb
+++ b/lib/calendlyr/resource.rb
@@ -48,19 +48,19 @@ module Calendlyr
     end
 
     def handle_response(response)
-      return true unless response.read_body
+      body_string = response.body.to_s
 
       body = begin
-        JSON.parse(response.read_body)
+        body_string.empty? ? {} : JSON.parse(body_string)
       rescue
         {}
       end
 
       if ERROR_CODES.include? response.code
         raise ResponseErrorHandler.new(response.code, body).error
-      else
-        body
       end
+
+      body.empty? ? true : body
     end
   end
 end

--- a/lib/calendlyr/resource.rb
+++ b/lib/calendlyr/resource.rb
@@ -60,7 +60,7 @@ module Calendlyr
         raise ResponseErrorHandler.new(response.code, body).error
       end
 
-      body.empty? ? true : body
+      body.empty? || body
     end
   end
 end


### PR DESCRIPTION
## Summary
- fix `handle_response` so it still checks status codes when the body is empty

------
https://chatgpt.com/codex/tasks/task_e_684800a92c048320a46a543264dc213b