### PR TITLE
Fix some doc typos

### DIFF
--- a/docs/resources/events/cancellation.md
+++ b/docs/resources/events/cancellation.md
@@ -13,6 +13,6 @@ Cancels specified event.
 Visit official [API Doc](https://developer.calendly.com/api-docs/afb2e9fe3a0a0-cancel-event)
 
 ```ruby
-client.events.cancel(uuid: event_uuid, reason: "I'm bussy")
+client.events.cancel(uuid: event_uuid, reason: "I'm busy")
 #=> #<Calendlyr::Events::Cancellation>
 ```

--- a/docs/resources/events/event.md
+++ b/docs/resources/events/event.md
@@ -41,7 +41,7 @@ Cancels specified event.
 Visit official [API Doc](https://developer.calendly.com/api-docs/afb2e9fe3a0a0-cancel-event)
 
 ```ruby
-client.events.cancel(uuid: event_uuid, reason: "I'm bussy")
+client.events.cancel(uuid: event_uuid, reason: "I'm busy")
 #=> #<Calendlyr::Events::Cancellation>
 ```
 
@@ -57,6 +57,6 @@ event.memberships
 ### Cancel
 
 ```ruby
-event.cancel(reason: "I'm bussy")
+event.cancel(reason: "I'm busy")
 #=> #<Calendlyr::Events::Cancellation>
 ```

--- a/docs/resources/share.md
+++ b/docs/resources/share.md
@@ -1,6 +1,6 @@
-# Share Calendlyr::Schare
+# Share Calendlyr::Share
 
-Schare Object.
+Share Object.
 
 Visit official [API Doc](https://developer.calendly.com/api-docs/0069948603238-share)
 

--- a/docs/resources/webhooks/invitee_payload.md
+++ b/docs/resources/webhooks/invitee_payload.md
@@ -1,4 +1,4 @@
-# Webhook Invitee Payload Calendlyr::Wehooks::InviteePayload
+# Webhooks Invitee Payload Calendlyr::Wehooks::InviteePayload
 
 The payload that is sent via Webhook when an invitee creates or schedules a meeting, and when an invitee cancels.
 

--- a/docs/resources/webhooks/payload.md
+++ b/docs/resources/webhooks/payload.md
@@ -1,4 +1,4 @@
-# Webhook Payload Calendlyr::Wehooks::Payload
+# Webhooks Payload Calendlyr::Wehooks::Payload
 
 Webhook Payload Object
 

--- a/docs/resources/webhooks/subscription.md
+++ b/docs/resources/webhooks/subscription.md
@@ -1,4 +1,4 @@
-# Webhook Subscription Calendlyr::Wehooks::Subscription
+# Webhooks Subscription Calendlyr::Wehooks::Subscription
 
 Webhook Subscription Object.
 


### PR DESCRIPTION
This pull request includes several documentation fixes to correct typos and improve clarity in the `docs/resources` directory. The most important changes include fixing spelling errors in code examples and correcting object names in headers.

### Fixes to code examples:

* Corrected the spelling of "I'm busy" in multiple code examples under event cancellation 

### Fixes to headers:

* Fixed a typo in the header for the Share object by changing "Schare" to "Share".
* Corrected the spelling of "Webhooks" in several headers under the webhooks documentation.