### PR TITLE
feat: complete Calendly API v2 coverage for v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.0]
+
+### Added
+* `GET /event_type_available_times` — `client.event_types.list_available_times(event_type:, start_time:, end_time:)` returns a `Collection` of `EventTypes::AvailableTime` objects. No pagination (not supported by this endpoint).
+* `GET /event_type_memberships` — `client.event_types.list_memberships(event_type:)` and `list_all_memberships`. Returns `EventTypes::Membership` objects.
+* `POST /scheduling_links` — `client.scheduling_links.create(owner:, owner_type:, max_event_count:)` returns a `SchedulingLink` object. Bare UUID expansion for `owner`.
+* `GET /organizations/{uuid}` — `client.organizations.retrieve(uuid:)` returns an `Organization` object.
+* `GET /outgoing_communications` — `client.outgoing_communications.list(organization:)` and `list_all`. Returns `OutgoingCommunication` objects.
+* `GET /sample_webhook_data` — `client.webhooks.sample(event:, organization:, scope:)` returns the raw response hash (shape varies by event type).
+
+### Notes
+* Version 1.0.0 signals complete Calendly API v2 coverage. All documented endpoints are now implemented.
+
+[1.0.0]: https://github.com/araluce/calendlyr/compare/v0.10.0...v1.0.0
+
 ## [0.11.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 ## [1.0.0]
 
 ### Added
+* Auto-pagination via `Enumerator::Lazy` — `collection.auto_paginate` returns a lazy enumerator that traverses all pages on demand without pre-fetching. Compose with `.take(n)`, `.select { }`, `.map { }`, etc.
+* `#next_page` method on `Collection` — returns the next page as a new `Collection`, or `nil` when there are no more pages.
+* `#next_page_url` attr_reader on `Collection` — exposes the raw next-page URL string.
+* `list_all` convenience methods on every resource with list endpoints:
+  - `client.events.list_all`, `client.events.list_all_invitees`
+  - `client.event_types.list_all`, `client.event_types.list_all_availability_schedules`, `client.event_types.list_all_memberships`
+  - `client.organizations.list_all_memberships`, `client.organizations.list_all_invitations`, `client.organizations.list_all_activity_log`
+  - `client.groups.list_all`, `client.groups.list_all_relationships`
+  - `client.availability.list_all_user_busy_times`, `client.availability.list_all_user_schedules`
+  - `client.routing_forms.list_all`, `client.routing_forms.list_all_submissions`
+  - `client.webhooks.list_all`
+  - `client.locations.list_all`
+  - `client.outgoing_communications.list_all`
 * `GET /event_type_available_times` — `client.event_types.list_available_times(event_type:, start_time:, end_time:)` returns a `Collection` of `EventTypes::AvailableTime` objects. No pagination (not supported by this endpoint).
 * `GET /event_type_memberships` — `client.event_types.list_memberships(event_type:)` and `list_all_memberships`. Returns `EventTypes::Membership` objects.
 * `POST /scheduling_links` — `client.scheduling_links.create(owner:, owner_type:, max_event_count:)` returns a `SchedulingLink` object. Bare UUID expansion for `owner`.
@@ -12,32 +25,15 @@ All notable changes to this project will be documented in this file.
 * `GET /outgoing_communications` — `client.outgoing_communications.list(organization:)` and `list_all`. Returns `OutgoingCommunication` objects.
 * `GET /sample_webhook_data` — `client.webhooks.sample(event:, organization:, scope:)` returns the raw response hash (shape varies by event type).
 
-### Notes
-* Version 1.0.0 signals complete Calendly API v2 coverage. All documented endpoints are now implemented.
-
-[1.0.0]: https://github.com/araluce/calendlyr/compare/v0.10.0...v1.0.0
-
-## [0.11.0]
-
-### Added
-* Auto-pagination via `Enumerator::Lazy` — `collection.auto_paginate` returns a lazy enumerator that traverses all pages on demand without pre-fetching. Compose with `.take(n)`, `.select { }`, `.map { }`, etc.
-* `#next_page` method on `Collection` — returns the next page as a new `Collection`, or `nil` when there are no more pages.
-* `#next_page_url` attr_reader on `Collection` — exposes the raw next-page URL string.
-* `list_all` convenience methods on every resource with list endpoints:
-  - `client.events.list_all`, `client.events.list_all_invitees`
-  - `client.event_types.list_all`, `client.event_types.list_all_availability_schedules`
-  - `client.organizations.list_all_memberships`, `client.organizations.list_all_invitations`, `client.organizations.list_all_activity_log`
-  - `client.groups.list_all`, `client.groups.list_all_relationships`
-  - `client.availability.list_all_user_busy_times`, `client.availability.list_all_user_schedules`
-  - `client.routing_forms.list_all`, `client.routing_forms.list_all_submissions`
-  - `client.webhooks.list_all`
-  - `client.locations.list_all`
-
 ### Changed — Breaking
 * **`Collection#next_page`** (attr_reader returning the raw URL string) is now **`Collection#next_page_url`**. If you were reading the raw next-page URL via `collection.next_page`, change to `collection.next_page_url`.
 * **`Collection#next_page`** is now a **method** that returns the next `Collection` object (or `nil`), not the raw URL string.
 
-[0.11.0]: https://github.com/araluce/calendlyr/compare/v0.10.0...v0.11.0
+### Notes
+* Version 1.0.0 signals complete Calendly API v2 coverage. All documented endpoints are now implemented.
+* Changes originally prepared for an unreleased `0.11.0` were shipped as part of `1.0.0`.
+
+[1.0.0]: https://github.com/araluce/calendlyr/compare/v0.10.0...v1.0.0
 
 ## [0.10.0]
 

--- a/README.md
+++ b/README.md
@@ -195,6 +195,8 @@ client.routing_forms.list_all_submissions(form: "YOUR_FORM_UUID")
 client.availability.list_all_user_busy_times(user: "YOUR_USER_UUID", start_time: "...", end_time: "...")
 client.availability.list_all_user_schedules(user: "YOUR_USER_UUID")
 client.locations.list_all
+client.event_types.list_all_memberships(event_type: "YOUR_EVENT_TYPE_UUID")
+client.outgoing_communications.list_all(organization: "YOUR_ORG_UUID")
 ```
 
 ### `auto_paginate` — Lazy Enumerator
@@ -214,19 +216,6 @@ active = collection.auto_paginate.select { |e| e.status == "active" }.first(10)
 collection.auto_paginate.each do |event|
   puts event.name
 end
-```
-
-### Breaking change in v0.11.0
-
-The `#next_page` attr_reader that previously returned the raw next-page URL string has been renamed to `#next_page_url`. The `#next_page` method now returns the **next Collection** (or `nil` if there are no more pages).
-
-```ruby
-# Before (v0.10.x):
-collection.next_page  #=> "https://api.calendly.com/...?page_token=..."
-
-# After (v0.11.0):
-collection.next_page_url  #=> "https://api.calendly.com/...?page_token=..."
-collection.next_page      #=> #<Calendlyr::Collection> or nil
 ```
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -7,9 +7,11 @@
 
 ![Calendlyr logo](logos/calendlyr_bg_white.png)
 
-The simplest way to interact with [Calendly's API v2](https://developer.calendly.com/api-docs) in Ruby. No dependencies, no complexity — just a Personal Access Token and you're good to go.
+The simplest way to interact with [Calendly's API v2](https://developer.calendly.com/api-docs) in Ruby. No runtime dependencies, no ceremony — just a Personal Access Token and you're good to go.
 
 ## Installation
+
+Calendlyr requires **Ruby >= 3.2.0**.
 
 Add to your Gemfile:
 
@@ -95,7 +97,7 @@ end
 
 ### Bare UUIDs
 
-Every method that takes a Calendly resource reference (like `user:`, `organization:`, `event_type:`) accepts both bare UUIDs and full URIs. The gem expands bare UUIDs automatically:
+Most methods that take a Calendly resource reference (like `user:`, `organization:`, `event_type:`, or `owner:`) accept both bare UUIDs and full URIs. When supported, the gem expands bare UUIDs automatically:
 
 ```ruby
 # Both are equivalent:
@@ -104,6 +106,8 @@ client.events.list(user: "https://api.calendly.com/users/YOUR_USER_UUID")
 ```
 
 The gem mirrors the Calendly API closely, so converting API examples into gem code is straightforward. Responses are wrapped in Ruby objects with dot-access for every field.
+
+> **Note:** A few endpoints still expect a full Calendly URI for specific parameters. When that matters, the resource docs call it out explicitly.
 
 ### Webhook signature verification
 
@@ -131,7 +135,7 @@ if Calendlyr::Webhook.valid?(payload: payload, signature_header: signature_heade
 end
 ```
 
-### JSON Serialization
+### JSON serialization
 
 All API objects support `#to_json` for easy serialization (caching, logging, API proxying):
 
@@ -151,7 +155,7 @@ parsed.name  #=> "30 Minute Meeting"
 
 > **Note:** `#to_json` and `#to_h` exclude the internal `client` reference — only API data is serialized.
 
-### Error Context
+### Error context
 
 API errors now include the HTTP method and path in the message, and expose structured attributes for debugging:
 
@@ -171,7 +175,7 @@ This makes debugging failed requests much easier without changing existing `resc
 
 ## Auto-pagination
 
-Calendlyr supports lazy auto-pagination for all collection endpoints. There are two ways to consume paginated results:
+Calendlyr supports lazy auto-pagination for paginated collection endpoints. There are two ways to consume paginated results:
 
 ### `list_all` — Eager, returns a flat Array
 
@@ -221,6 +225,8 @@ end
 ## Documentation
 
 For the full list of available resources and methods, check out the [API Reference](docs/resources/).
+
+The docs in this repository focus on the Ruby wrapper API. For request/response schemas and endpoint-level behavior, use the official Calendly API docs linked from each resource page.
 
 ## Contributing
 

--- a/docs/resources/event_types/available_time.md
+++ b/docs/resources/event_types/available_time.md
@@ -1,0 +1,25 @@
+# Available Time (`Calendlyr::EventTypes::AvailableTime`)
+
+Available time for a specific Event Type in a given time window.
+
+Visit official [API Doc](https://developer.calendly.com/api-docs)
+
+## Client requests
+
+### List Available Times
+
+Returns available time slots for an Event Type between `start_time` and `end_time`.
+
+Visit official [API Doc](https://developer.calendly.com/api-docs)
+
+```ruby
+# event_type: accepts a bare UUID or full Calendly URI
+client.event_types.list_available_times(
+  event_type: "EVENT_TYPE_UUID",
+  start_time: "2026-04-07T09:00:00Z",
+  end_time: "2026-04-07T18:00:00Z"
+)
+#=> #<Calendlyr::Collection @data=[#<Calendlyr::EventTypes::AvailableTime>, ...], ...>
+```
+
+This endpoint does not support pagination.

--- a/docs/resources/event_types/membership.md
+++ b/docs/resources/event_types/membership.md
@@ -1,0 +1,28 @@
+# Event Type Membership (`Calendlyr::EventTypes::Membership`)
+
+Membership object for an Event Type.
+
+Visit official [API Doc](https://developer.calendly.com/api-docs)
+
+## Client requests
+
+### List
+
+Returns memberships for a specified Event Type.
+
+Visit official [API Doc](https://developer.calendly.com/api-docs)
+
+```ruby
+# event_type: accepts a bare UUID or full Calendly URI
+client.event_types.list_memberships(event_type: "EVENT_TYPE_UUID")
+#=> #<Calendlyr::Collection @data=[#<Calendlyr::EventTypes::Membership>, ...], ...>
+```
+
+### List All
+
+Fetches every membership page and returns a flat Array.
+
+```ruby
+client.event_types.list_all_memberships(event_type: "EVENT_TYPE_UUID")
+#=> [#<Calendlyr::EventTypes::Membership>, ...]
+```

--- a/docs/resources/organizations/organization.md
+++ b/docs/resources/organizations/organization.md
@@ -13,6 +13,19 @@ organization = client.organization
 #=> #<Calendlyr::Organization>
 ```
 
+## Client requests
+
+### Retrieve
+
+Returns information about a specified Organization.
+
+Visit official [API Doc](https://developer.calendly.com/api-docs)
+
+```ruby
+client.organizations.retrieve(uuid: "ORG_UUID")
+#=> #<Calendlyr::Organization>
+```
+
 ## Object methods
 
 ### Activity Logs

--- a/docs/resources/outgoing_communications/outgoing_communication.md
+++ b/docs/resources/outgoing_communications/outgoing_communication.md
@@ -1,0 +1,28 @@
+# Outgoing Communication (`Calendlyr::OutgoingCommunication`)
+
+Outgoing communication object.
+
+Visit official [API Doc](https://developer.calendly.com/api-docs)
+
+## Client requests
+
+### List
+
+Returns outgoing communications for a specified Organization.
+
+Visit official [API Doc](https://developer.calendly.com/api-docs)
+
+```ruby
+# organization: accepts a bare UUID or full Calendly URI
+client.outgoing_communications.list(organization: "ORG_UUID")
+#=> #<Calendlyr::Collection @data=[#<Calendlyr::OutgoingCommunication>, ...], ...>
+```
+
+### List All
+
+Fetches every page and returns a flat Array.
+
+```ruby
+client.outgoing_communications.list_all(organization: "ORG_UUID")
+#=> [#<Calendlyr::OutgoingCommunication>, ...]
+```

--- a/docs/resources/scheduling_links/scheduling_link.md
+++ b/docs/resources/scheduling_links/scheduling_link.md
@@ -1,0 +1,26 @@
+# Scheduling Link (`Calendlyr::SchedulingLink`)
+
+Scheduling link object.
+
+Visit official [API Doc](https://developer.calendly.com/api-docs)
+
+## Client requests
+
+### Create
+
+Creates a scheduling link for an Event Type owner.
+
+Visit official [API Doc](https://developer.calendly.com/api-docs)
+
+```ruby
+# owner: accepts a bare UUID or full Calendly URI
+client.scheduling_links.create(owner: "EVENT_TYPE_UUID")
+#=> #<Calendlyr::SchedulingLink>
+
+client.scheduling_links.create(
+  owner: "EVENT_TYPE_UUID",
+  owner_type: "EventType",
+  max_event_count: 3
+)
+#=> #<Calendlyr::SchedulingLink>
+```

--- a/docs/resources/webhooks/sample.md
+++ b/docs/resources/webhooks/sample.md
@@ -1,0 +1,23 @@
+# Sample Webhook Data
+
+Fetch sample webhook payload data for a given event, organization, and scope.
+
+Visit official [API Doc](https://developer.calendly.com/api-docs)
+
+## Client requests
+
+### Sample
+
+Returns raw sample webhook data. The response shape varies by event type, so this method returns the raw response hash instead of a typed object.
+
+Visit official [API Doc](https://developer.calendly.com/api-docs)
+
+```ruby
+# organization: accepts a bare UUID or full Calendly URI
+client.webhooks.sample(
+  event: "invitee.created",
+  organization: "ORG_UUID",
+  scope: "organization"
+)
+#=> { "payload" => { ... } }
+```

--- a/lib/calendlyr.rb
+++ b/lib/calendlyr.rb
@@ -72,7 +72,9 @@ module Calendlyr
   autoload :GroupsResource, "calendlyr/resources/groups"
   autoload :OrganizationsResource, "calendlyr/resources/organizations"
   autoload :LocationsResource, "calendlyr/resources/locations"
+  autoload :OutgoingCommunicationsResource, "calendlyr/resources/outgoing_communications"
   autoload :RoutingFormsResource, "calendlyr/resources/routing_forms"
+  autoload :SchedulingLinksResource, "calendlyr/resources/scheduling_links"
   autoload :SharesResource, "calendlyr/resources/shares"
   autoload :UsersResource, "calendlyr/resources/users"
   autoload :WebhooksResource, "calendlyr/resources/webhooks"
@@ -84,7 +86,9 @@ module Calendlyr
   autoload :Group, "calendlyr/objects/group"
   autoload :Organization, "calendlyr/objects/organization"
   autoload :Location, "calendlyr/objects/location"
+  autoload :OutgoingCommunication, "calendlyr/objects/outgoing_communication"
   autoload :RoutingForm, "calendlyr/objects/routing_form"
+  autoload :SchedulingLink, "calendlyr/objects/scheduling_link"
   autoload :Share, "calendlyr/objects/share"
   autoload :User, "calendlyr/objects/user"
 
@@ -103,6 +107,8 @@ module Calendlyr
 
   module EventTypes
     autoload :AvailabilitySchedule, "calendlyr/objects/event_types/availability_schedule"
+    autoload :AvailableTime, "calendlyr/objects/event_types/available_time"
+    autoload :Membership, "calendlyr/objects/event_types/membership"
     autoload :Profile, "calendlyr/objects/event_types/profile"
   end
 

--- a/lib/calendlyr/objects/event_types/available_time.rb
+++ b/lib/calendlyr/objects/event_types/available_time.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Calendlyr
+  module EventTypes
+    class AvailableTime < Object
+    end
+  end
+end

--- a/lib/calendlyr/objects/event_types/membership.rb
+++ b/lib/calendlyr/objects/event_types/membership.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module Calendlyr
+  module EventTypes
+    class Membership < Object
+    end
+  end
+end

--- a/lib/calendlyr/objects/outgoing_communication.rb
+++ b/lib/calendlyr/objects/outgoing_communication.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module Calendlyr
+  class OutgoingCommunication < Object
+  end
+end

--- a/lib/calendlyr/objects/scheduling_link.rb
+++ b/lib/calendlyr/objects/scheduling_link.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module Calendlyr
+  class SchedulingLink < Object
+  end
+end

--- a/lib/calendlyr/resources/event_types.rb
+++ b/lib/calendlyr/resources/event_types.rb
@@ -17,12 +17,12 @@ module Calendlyr
     end
 
     def create_one_off(name:, host:, duration:, date_setting:, location:, **params)
-      body = {name: name, host: host, duration: duration, date_setting: date_setting, location: location}.merge(params)
+      body = { name: name, host: host, duration: duration, date_setting: date_setting, location: location }.merge(params)
       EventType.new post_request("one_off_event_types", body: body).dig("resource").merge(client: client)
     end
 
     def create(name:, duration:, pooling_type:, **params)
-      body = {name: name, duration: duration, pooling_type: pooling_type}.merge(params)
+      body = { name: name, duration: duration, pooling_type: pooling_type }.merge(params)
       EventType.new post_request("event_types", body: body).dig("resource").merge(client: client)
     end
 
@@ -33,7 +33,7 @@ module Calendlyr
     # Availability Schedules
     def list_availability_schedules(event_type_uuid:, **params)
       next_page_caller = ->(page_token:) { list_availability_schedules(event_type_uuid: event_type_uuid, **params, page_token: page_token) }
-      response = get_request("event_type_availability_schedules", params: {event_type_uuid: event_type_uuid}.merge(params))
+      response = get_request("event_type_availability_schedules", params: { event_type_uuid: event_type_uuid }.merge(params))
       Collection.from_response(response, type: EventTypes::AvailabilitySchedule, client: client, next_page_caller: next_page_caller)
     end
 
@@ -42,8 +42,27 @@ module Calendlyr
     end
 
     def update_availability_schedule(event_type_uuid:, availability_schedules:, **params)
-      body = {event_type_uuid: event_type_uuid, availability_schedules: availability_schedules}.merge(params)
+      body = { event_type_uuid: event_type_uuid, availability_schedules: availability_schedules }.merge(params)
       patch_request("event_type_availability_schedules", body: body)
+    end
+
+    # Available Times (no pagination — endpoint does not support it)
+    def list_available_times(event_type:, start_time:, end_time:, **params)
+      event_type = expand_uri(event_type, "event_types")
+      response = get_request("event_type_available_times", params: { event_type: event_type, start_time: start_time, end_time: end_time }.merge(params))
+      Collection.from_response(response, type: EventTypes::AvailableTime, client: client)
+    end
+
+    # Event Type Memberships
+    def list_memberships(event_type:, **params)
+      next_page_caller = ->(page_token:) { list_memberships(event_type: event_type, **params, page_token: page_token) }
+      event_type = expand_uri(event_type, "event_types")
+      response = get_request("event_type_memberships", params: { event_type: event_type }.merge(params))
+      Collection.from_response(response, type: EventTypes::Membership, client: client, next_page_caller: next_page_caller)
+    end
+
+    def list_all_memberships(event_type:, **params)
+      list_memberships(event_type: event_type, **params).auto_paginate.to_a
     end
   end
 end

--- a/lib/calendlyr/resources/event_types.rb
+++ b/lib/calendlyr/resources/event_types.rb
@@ -17,12 +17,12 @@ module Calendlyr
     end
 
     def create_one_off(name:, host:, duration:, date_setting:, location:, **params)
-      body = { name: name, host: host, duration: duration, date_setting: date_setting, location: location }.merge(params)
+      body = {name: name, host: host, duration: duration, date_setting: date_setting, location: location}.merge(params)
       EventType.new post_request("one_off_event_types", body: body).dig("resource").merge(client: client)
     end
 
     def create(name:, duration:, pooling_type:, **params)
-      body = { name: name, duration: duration, pooling_type: pooling_type }.merge(params)
+      body = {name: name, duration: duration, pooling_type: pooling_type}.merge(params)
       EventType.new post_request("event_types", body: body).dig("resource").merge(client: client)
     end
 
@@ -33,7 +33,7 @@ module Calendlyr
     # Availability Schedules
     def list_availability_schedules(event_type_uuid:, **params)
       next_page_caller = ->(page_token:) { list_availability_schedules(event_type_uuid: event_type_uuid, **params, page_token: page_token) }
-      response = get_request("event_type_availability_schedules", params: { event_type_uuid: event_type_uuid }.merge(params))
+      response = get_request("event_type_availability_schedules", params: {event_type_uuid: event_type_uuid}.merge(params))
       Collection.from_response(response, type: EventTypes::AvailabilitySchedule, client: client, next_page_caller: next_page_caller)
     end
 
@@ -42,14 +42,14 @@ module Calendlyr
     end
 
     def update_availability_schedule(event_type_uuid:, availability_schedules:, **params)
-      body = { event_type_uuid: event_type_uuid, availability_schedules: availability_schedules }.merge(params)
+      body = {event_type_uuid: event_type_uuid, availability_schedules: availability_schedules}.merge(params)
       patch_request("event_type_availability_schedules", body: body)
     end
 
     # Available Times (no pagination — endpoint does not support it)
     def list_available_times(event_type:, start_time:, end_time:, **params)
       event_type = expand_uri(event_type, "event_types")
-      response = get_request("event_type_available_times", params: { event_type: event_type, start_time: start_time, end_time: end_time }.merge(params))
+      response = get_request("event_type_available_times", params: {event_type: event_type, start_time: start_time, end_time: end_time}.merge(params))
       Collection.from_response(response, type: EventTypes::AvailableTime, client: client)
     end
 
@@ -57,7 +57,7 @@ module Calendlyr
     def list_memberships(event_type:, **params)
       next_page_caller = ->(page_token:) { list_memberships(event_type: event_type, **params, page_token: page_token) }
       event_type = expand_uri(event_type, "event_types")
-      response = get_request("event_type_memberships", params: { event_type: event_type }.merge(params))
+      response = get_request("event_type_memberships", params: {event_type: event_type}.merge(params))
       Collection.from_response(response, type: EventTypes::Membership, client: client, next_page_caller: next_page_caller)
     end
 

--- a/lib/calendlyr/resources/organizations.rb
+++ b/lib/calendlyr/resources/organizations.rb
@@ -1,9 +1,13 @@
 module Calendlyr
   class OrganizationsResource < Resource
+    def retrieve(uuid:)
+      Organization.new get_request("organizations/#{uuid}").dig("resource").merge(client: client)
+    end
+
     def activity_log(organization: nil, **params)
       next_page_caller = ->(page_token:) { activity_log(organization: organization, **params, page_token: page_token) }
       organization = expand_uri(organization, "organizations")
-      response = get_request("activity_log_entries", params: {organization: organization}.merge(params).compact)
+      response = get_request("activity_log_entries", params: { organization: organization }.merge(params).compact)
       Collection.from_response(response, type: ActivityLog, client: client, next_page_caller: next_page_caller)
     end
 
@@ -48,7 +52,7 @@ module Calendlyr
     end
 
     def invite(organization_uuid:, email:)
-      Organizations::Invitation.new post_request("organizations/#{organization_uuid}/invitations", body: {email: email}).dig("resource").merge(client: client)
+      Organizations::Invitation.new post_request("organizations/#{organization_uuid}/invitations", body: { email: email }).dig("resource").merge(client: client)
     end
 
     def revoke_invitation(org_uuid:, uuid:)

--- a/lib/calendlyr/resources/organizations.rb
+++ b/lib/calendlyr/resources/organizations.rb
@@ -7,7 +7,7 @@ module Calendlyr
     def activity_log(organization: nil, **params)
       next_page_caller = ->(page_token:) { activity_log(organization: organization, **params, page_token: page_token) }
       organization = expand_uri(organization, "organizations")
-      response = get_request("activity_log_entries", params: { organization: organization }.merge(params).compact)
+      response = get_request("activity_log_entries", params: {organization: organization}.merge(params).compact)
       Collection.from_response(response, type: ActivityLog, client: client, next_page_caller: next_page_caller)
     end
 
@@ -52,7 +52,7 @@ module Calendlyr
     end
 
     def invite(organization_uuid:, email:)
-      Organizations::Invitation.new post_request("organizations/#{organization_uuid}/invitations", body: { email: email }).dig("resource").merge(client: client)
+      Organizations::Invitation.new post_request("organizations/#{organization_uuid}/invitations", body: {email: email}).dig("resource").merge(client: client)
     end
 
     def revoke_invitation(org_uuid:, uuid:)

--- a/lib/calendlyr/resources/outgoing_communications.rb
+++ b/lib/calendlyr/resources/outgoing_communications.rb
@@ -5,7 +5,7 @@ module Calendlyr
     def list(organization:, **params)
       next_page_caller = ->(page_token:) { list(organization: organization, **params, page_token: page_token) }
       organization = expand_uri(organization, "organizations")
-      response = get_request("outgoing_communications", params: { organization: organization }.merge(params))
+      response = get_request("outgoing_communications", params: {organization: organization}.merge(params))
       Collection.from_response(response, type: OutgoingCommunication, client: client, next_page_caller: next_page_caller)
     end
 

--- a/lib/calendlyr/resources/outgoing_communications.rb
+++ b/lib/calendlyr/resources/outgoing_communications.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Calendlyr
+  class OutgoingCommunicationsResource < Resource
+    def list(organization:, **params)
+      next_page_caller = ->(page_token:) { list(organization: organization, **params, page_token: page_token) }
+      organization = expand_uri(organization, "organizations")
+      response = get_request("outgoing_communications", params: { organization: organization }.merge(params))
+      Collection.from_response(response, type: OutgoingCommunication, client: client, next_page_caller: next_page_caller)
+    end
+
+    def list_all(organization:, **params)
+      list(organization: organization, **params).auto_paginate.to_a
+    end
+  end
+end

--- a/lib/calendlyr/resources/scheduling_links.rb
+++ b/lib/calendlyr/resources/scheduling_links.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Calendlyr
+  class SchedulingLinksResource < Resource
+    def create(owner:, owner_type: "EventType", max_event_count: 1)
+      owner = expand_uri(owner, "event_types")
+      body = { max_event_count: max_event_count, owner: owner, owner_type: owner_type }
+      SchedulingLink.new post_request("scheduling_links", body: body).dig("resource").merge(client: client)
+    end
+  end
+end

--- a/lib/calendlyr/resources/scheduling_links.rb
+++ b/lib/calendlyr/resources/scheduling_links.rb
@@ -4,7 +4,7 @@ module Calendlyr
   class SchedulingLinksResource < Resource
     def create(owner:, owner_type: "EventType", max_event_count: 1)
       owner = expand_uri(owner, "event_types")
-      body = { max_event_count: max_event_count, owner: owner, owner_type: owner_type }
+      body = {max_event_count: max_event_count, owner: owner, owner_type: owner_type}
       SchedulingLink.new post_request("scheduling_links", body: body).dig("resource").merge(client: client)
     end
   end

--- a/lib/calendlyr/resources/webhooks.rb
+++ b/lib/calendlyr/resources/webhooks.rb
@@ -27,7 +27,7 @@ module Calendlyr
 
     def sample(event:, organization:, scope:, **params)
       organization = expand_uri(organization, "organizations")
-      get_request("sample_webhook_data", params: { event: event, organization: organization, scope: scope }.merge(params))
+      get_request("sample_webhook_data", params: {event: event, organization: organization, scope: scope}.merge(params))
     end
   end
 end

--- a/lib/calendlyr/resources/webhooks.rb
+++ b/lib/calendlyr/resources/webhooks.rb
@@ -24,5 +24,10 @@ module Calendlyr
     def delete(webhook_uuid:)
       delete_request("webhook_subscriptions/#{webhook_uuid}")
     end
+
+    def sample(event:, organization:, scope:, **params)
+      organization = expand_uri(organization, "organizations")
+      get_request("sample_webhook_data", params: { event: event, organization: organization, scope: scope }.merge(params))
+    end
   end
 end

--- a/lib/calendlyr/version.rb
+++ b/lib/calendlyr/version.rb
@@ -1,3 +1,3 @@
 module Calendlyr
-  VERSION = "0.10.0"
+  VERSION = "1.0.0"
 end

--- a/test/calendlyr/resources/event_types_test.rb
+++ b/test/calendlyr/resources/event_types_test.rb
@@ -7,11 +7,11 @@ class EventTypesResourceTest < Minitest::Test
     @user_uri = "https://api.calendly.com/users/abc123"
     @organization_uri = "https://api.calendly.com/organizations/abc123"
     @event_type_uuid = "AAAAAAAAAAAAAAAA"
-    list_response = {body: fixture_file("event_types/list"), status: 200}
+    list_response = { body: fixture_file("event_types/list"), status: 200 }
     stub(path: "event_types?user=#{@user_uri}&organization=#{@organization_uri}", response: list_response)
     stub(path: "event_types?organization=#{@organization_uri}", response: list_response)
     stub(path: "event_types?user=#{@user_uri}", response: list_response)
-    retrieve_response = {body: fixture_file("event_types/retrieve"), status: 200}
+    retrieve_response = { body: fixture_file("event_types/retrieve"), status: 200 }
     stub(path: "event_types/#{@event_type_uuid}", response: retrieve_response)
   end
 
@@ -64,7 +64,7 @@ class EventTypesResourceTest < Minitest::Test
         additonal_info: "string"
       }
     }
-    stub(method: :post, path: "one_off_event_types", response: {body: fixture_file("event_types/create_one_off"), status: 201})
+    stub(method: :post, path: "one_off_event_types", response: { body: fixture_file("event_types/create_one_off"), status: 201 })
     event_type = client.event_types.create_one_off(**body)
 
     assert_equal Calendlyr::EventType, event_type.class
@@ -80,7 +80,7 @@ class EventTypesResourceTest < Minitest::Test
       duration: 30,
       pooling_type: "round_robin"
     }
-    stub(method: :post, path: "event_types", response: {body: fixture_file("event_types/create"), status: 201})
+    stub(method: :post, path: "event_types", response: { body: fixture_file("event_types/create"), status: 201 })
     event_type = client.event_types.create(**body)
 
     assert_equal Calendlyr::EventType, event_type.class
@@ -90,7 +90,7 @@ class EventTypesResourceTest < Minitest::Test
   end
 
   def test_update
-    stub(method: :patch, path: "event_types/#{@event_type_uuid}", response: {body: fixture_file("event_types/update"), status: 200})
+    stub(method: :patch, path: "event_types/#{@event_type_uuid}", response: { body: fixture_file("event_types/update"), status: 200 })
     event_type = client.event_types.update(uuid: @event_type_uuid, name: "Updated Meeting", duration: 45)
 
     assert_equal Calendlyr::EventType, event_type.class
@@ -102,7 +102,7 @@ class EventTypesResourceTest < Minitest::Test
   def test_list_with_bare_user_uuid
     bare_uuid = "abc123"
     expanded = "https://api.calendly.com/users/#{bare_uuid}"
-    stub(path: "event_types?user=#{expanded}", response: {body: fixture_file("event_types/list"), status: 200})
+    stub(path: "event_types?user=#{expanded}", response: { body: fixture_file("event_types/list"), status: 200 })
 
     event_types = client.event_types.list(user: bare_uuid)
 
@@ -113,7 +113,7 @@ class EventTypesResourceTest < Minitest::Test
   def test_list_with_bare_org_uuid
     bare_uuid = "abc123"
     expanded = "https://api.calendly.com/organizations/#{bare_uuid}"
-    stub(path: "event_types?organization=#{expanded}", response: {body: fixture_file("event_types/list"), status: 200})
+    stub(path: "event_types?organization=#{expanded}", response: { body: fixture_file("event_types/list"), status: 200 })
 
     event_types = client.event_types.list(organization: bare_uuid)
 
@@ -122,7 +122,7 @@ class EventTypesResourceTest < Minitest::Test
   end
 
   def test_list_availability_schedules
-    stub(path: "event_type_availability_schedules?event_type_uuid=AAAAAAAAAAAAAAAA", response: {body: fixture_file("event_type_availability_schedules/list"), status: 200})
+    stub(path: "event_type_availability_schedules?event_type_uuid=AAAAAAAAAAAAAAAA", response: { body: fixture_file("event_type_availability_schedules/list"), status: 200 })
     schedules = client.event_types.list_availability_schedules(event_type_uuid: "AAAAAAAAAAAAAAAA")
 
     assert_equal Calendlyr::Collection, schedules.class
@@ -134,10 +134,10 @@ class EventTypesResourceTest < Minitest::Test
     body = {
       event_type_uuid: "AAAAAAAAAAAAAAAA",
       availability_schedules: [
-        {start_time: "2023-10-27T09:00:00Z", end_time: "2023-10-27T12:00:00Z"}
+        { start_time: "2023-10-27T09:00:00Z", end_time: "2023-10-27T12:00:00Z" }
       ]
     }
-    stub(method: :patch, path: "event_type_availability_schedules", response: {body: fixture_file("event_type_availability_schedules/update"), status: 200})
+    stub(method: :patch, path: "event_type_availability_schedules", response: { body: fixture_file("event_type_availability_schedules/update"), status: 200 })
     result = client.event_types.update_availability_schedule(**body)
 
     assert result
@@ -147,12 +147,62 @@ class EventTypesResourceTest < Minitest::Test
   def test_list_all_returns_all_pages
     token = "sNjq4TvMDfUHEl7zHRR0k0E1PCEJWvdi"
     page2_path = "event_types?user=#{@user_uri}&organization=#{@organization_uri}&page_token=#{token}"
-    stub(path: page2_path, response: {body: fixture_file("event_types/list_page2"), status: 200})
+    stub(path: page2_path, response: { body: fixture_file("event_types/list_page2"), status: 200 })
 
     event_types = client.event_types.list_all(user: @user_uri, organization: @organization_uri)
 
     assert_equal Array, event_types.class
     assert_equal 2, event_types.size
     assert_equal Calendlyr::EventType, event_types.first.class
+  end
+
+  def test_list_available_times
+    event_type_uri = "https://api.calendly.com/event_types/AAAAAAAAAAAAAAAA"
+    start_time = "2020-01-01T00:00:00.000000Z"
+    end_time = "2020-01-02T00:00:00.000000Z"
+    stub(path: "event_type_available_times?event_type=#{event_type_uri}&start_time=#{start_time}&end_time=#{end_time}", response: { body: fixture_file("event_type_available_times/list"), status: 200 })
+
+    times = client.event_types.list_available_times(event_type: event_type_uri, start_time: start_time, end_time: end_time)
+
+    assert_equal Calendlyr::Collection, times.class
+    assert_equal Calendlyr::EventTypes::AvailableTime, times.data.first.class
+    assert_equal 1, times.data.count
+    assert_equal "available", times.data.first.status
+  end
+
+  def test_list_memberships
+    event_type_uri = "https://api.calendly.com/event_types/AAAAAAAAAAAAAAAA"
+    stub(path: "event_type_memberships?event_type=#{event_type_uri}", response: { body: fixture_file("event_type_memberships/list"), status: 200 })
+
+    memberships = client.event_types.list_memberships(event_type: event_type_uri)
+
+    assert_equal Calendlyr::Collection, memberships.class
+    assert_equal Calendlyr::EventTypes::Membership, memberships.data.first.class
+    assert_equal 1, memberships.data.count
+    assert_equal "sNjq4TvMDfUHEl7zHRR0k0E1PCEJWvdi", memberships.next_page_token
+  end
+
+  def test_list_memberships_with_bare_event_type_uuid
+    bare_uuid = "AAAAAAAAAAAAAAAA"
+    expanded = "https://api.calendly.com/event_types/#{bare_uuid}"
+    stub(path: "event_type_memberships?event_type=#{expanded}", response: { body: fixture_file("event_type_memberships/list"), status: 200 })
+
+    memberships = client.event_types.list_memberships(event_type: bare_uuid)
+
+    assert_equal Calendlyr::Collection, memberships.class
+    assert_equal 1, memberships.data.count
+  end
+
+  def test_list_all_memberships_returns_all_pages
+    event_type_uri = "https://api.calendly.com/event_types/AAAAAAAAAAAAAAAA"
+    token = "sNjq4TvMDfUHEl7zHRR0k0E1PCEJWvdi"
+    stub(path: "event_type_memberships?event_type=#{event_type_uri}", response: { body: fixture_file("event_type_memberships/list"), status: 200 })
+    stub(path: "event_type_memberships?event_type=#{event_type_uri}&page_token=#{token}", response: { body: fixture_file("event_type_memberships/list_page2"), status: 200 })
+
+    memberships = client.event_types.list_all_memberships(event_type: event_type_uri)
+
+    assert_equal Array, memberships.class
+    assert_equal 2, memberships.size
+    assert_equal Calendlyr::EventTypes::Membership, memberships.first.class
   end
 end

--- a/test/calendlyr/resources/event_types_test.rb
+++ b/test/calendlyr/resources/event_types_test.rb
@@ -7,11 +7,11 @@ class EventTypesResourceTest < Minitest::Test
     @user_uri = "https://api.calendly.com/users/abc123"
     @organization_uri = "https://api.calendly.com/organizations/abc123"
     @event_type_uuid = "AAAAAAAAAAAAAAAA"
-    list_response = { body: fixture_file("event_types/list"), status: 200 }
+    list_response = {body: fixture_file("event_types/list"), status: 200}
     stub(path: "event_types?user=#{@user_uri}&organization=#{@organization_uri}", response: list_response)
     stub(path: "event_types?organization=#{@organization_uri}", response: list_response)
     stub(path: "event_types?user=#{@user_uri}", response: list_response)
-    retrieve_response = { body: fixture_file("event_types/retrieve"), status: 200 }
+    retrieve_response = {body: fixture_file("event_types/retrieve"), status: 200}
     stub(path: "event_types/#{@event_type_uuid}", response: retrieve_response)
   end
 
@@ -64,7 +64,7 @@ class EventTypesResourceTest < Minitest::Test
         additonal_info: "string"
       }
     }
-    stub(method: :post, path: "one_off_event_types", response: { body: fixture_file("event_types/create_one_off"), status: 201 })
+    stub(method: :post, path: "one_off_event_types", response: {body: fixture_file("event_types/create_one_off"), status: 201})
     event_type = client.event_types.create_one_off(**body)
 
     assert_equal Calendlyr::EventType, event_type.class
@@ -80,7 +80,7 @@ class EventTypesResourceTest < Minitest::Test
       duration: 30,
       pooling_type: "round_robin"
     }
-    stub(method: :post, path: "event_types", response: { body: fixture_file("event_types/create"), status: 201 })
+    stub(method: :post, path: "event_types", response: {body: fixture_file("event_types/create"), status: 201})
     event_type = client.event_types.create(**body)
 
     assert_equal Calendlyr::EventType, event_type.class
@@ -90,7 +90,7 @@ class EventTypesResourceTest < Minitest::Test
   end
 
   def test_update
-    stub(method: :patch, path: "event_types/#{@event_type_uuid}", response: { body: fixture_file("event_types/update"), status: 200 })
+    stub(method: :patch, path: "event_types/#{@event_type_uuid}", response: {body: fixture_file("event_types/update"), status: 200})
     event_type = client.event_types.update(uuid: @event_type_uuid, name: "Updated Meeting", duration: 45)
 
     assert_equal Calendlyr::EventType, event_type.class
@@ -102,7 +102,7 @@ class EventTypesResourceTest < Minitest::Test
   def test_list_with_bare_user_uuid
     bare_uuid = "abc123"
     expanded = "https://api.calendly.com/users/#{bare_uuid}"
-    stub(path: "event_types?user=#{expanded}", response: { body: fixture_file("event_types/list"), status: 200 })
+    stub(path: "event_types?user=#{expanded}", response: {body: fixture_file("event_types/list"), status: 200})
 
     event_types = client.event_types.list(user: bare_uuid)
 
@@ -113,7 +113,7 @@ class EventTypesResourceTest < Minitest::Test
   def test_list_with_bare_org_uuid
     bare_uuid = "abc123"
     expanded = "https://api.calendly.com/organizations/#{bare_uuid}"
-    stub(path: "event_types?organization=#{expanded}", response: { body: fixture_file("event_types/list"), status: 200 })
+    stub(path: "event_types?organization=#{expanded}", response: {body: fixture_file("event_types/list"), status: 200})
 
     event_types = client.event_types.list(organization: bare_uuid)
 
@@ -122,7 +122,7 @@ class EventTypesResourceTest < Minitest::Test
   end
 
   def test_list_availability_schedules
-    stub(path: "event_type_availability_schedules?event_type_uuid=AAAAAAAAAAAAAAAA", response: { body: fixture_file("event_type_availability_schedules/list"), status: 200 })
+    stub(path: "event_type_availability_schedules?event_type_uuid=AAAAAAAAAAAAAAAA", response: {body: fixture_file("event_type_availability_schedules/list"), status: 200})
     schedules = client.event_types.list_availability_schedules(event_type_uuid: "AAAAAAAAAAAAAAAA")
 
     assert_equal Calendlyr::Collection, schedules.class
@@ -134,10 +134,10 @@ class EventTypesResourceTest < Minitest::Test
     body = {
       event_type_uuid: "AAAAAAAAAAAAAAAA",
       availability_schedules: [
-        { start_time: "2023-10-27T09:00:00Z", end_time: "2023-10-27T12:00:00Z" }
+        {start_time: "2023-10-27T09:00:00Z", end_time: "2023-10-27T12:00:00Z"}
       ]
     }
-    stub(method: :patch, path: "event_type_availability_schedules", response: { body: fixture_file("event_type_availability_schedules/update"), status: 200 })
+    stub(method: :patch, path: "event_type_availability_schedules", response: {body: fixture_file("event_type_availability_schedules/update"), status: 200})
     result = client.event_types.update_availability_schedule(**body)
 
     assert result
@@ -147,7 +147,7 @@ class EventTypesResourceTest < Minitest::Test
   def test_list_all_returns_all_pages
     token = "sNjq4TvMDfUHEl7zHRR0k0E1PCEJWvdi"
     page2_path = "event_types?user=#{@user_uri}&organization=#{@organization_uri}&page_token=#{token}"
-    stub(path: page2_path, response: { body: fixture_file("event_types/list_page2"), status: 200 })
+    stub(path: page2_path, response: {body: fixture_file("event_types/list_page2"), status: 200})
 
     event_types = client.event_types.list_all(user: @user_uri, organization: @organization_uri)
 
@@ -160,7 +160,7 @@ class EventTypesResourceTest < Minitest::Test
     event_type_uri = "https://api.calendly.com/event_types/AAAAAAAAAAAAAAAA"
     start_time = "2020-01-01T00:00:00.000000Z"
     end_time = "2020-01-02T00:00:00.000000Z"
-    stub(path: "event_type_available_times?event_type=#{event_type_uri}&start_time=#{start_time}&end_time=#{end_time}", response: { body: fixture_file("event_type_available_times/list"), status: 200 })
+    stub(path: "event_type_available_times?event_type=#{event_type_uri}&start_time=#{start_time}&end_time=#{end_time}", response: {body: fixture_file("event_type_available_times/list"), status: 200})
 
     times = client.event_types.list_available_times(event_type: event_type_uri, start_time: start_time, end_time: end_time)
 
@@ -172,7 +172,7 @@ class EventTypesResourceTest < Minitest::Test
 
   def test_list_memberships
     event_type_uri = "https://api.calendly.com/event_types/AAAAAAAAAAAAAAAA"
-    stub(path: "event_type_memberships?event_type=#{event_type_uri}", response: { body: fixture_file("event_type_memberships/list"), status: 200 })
+    stub(path: "event_type_memberships?event_type=#{event_type_uri}", response: {body: fixture_file("event_type_memberships/list"), status: 200})
 
     memberships = client.event_types.list_memberships(event_type: event_type_uri)
 
@@ -185,7 +185,7 @@ class EventTypesResourceTest < Minitest::Test
   def test_list_memberships_with_bare_event_type_uuid
     bare_uuid = "AAAAAAAAAAAAAAAA"
     expanded = "https://api.calendly.com/event_types/#{bare_uuid}"
-    stub(path: "event_type_memberships?event_type=#{expanded}", response: { body: fixture_file("event_type_memberships/list"), status: 200 })
+    stub(path: "event_type_memberships?event_type=#{expanded}", response: {body: fixture_file("event_type_memberships/list"), status: 200})
 
     memberships = client.event_types.list_memberships(event_type: bare_uuid)
 
@@ -196,8 +196,8 @@ class EventTypesResourceTest < Minitest::Test
   def test_list_all_memberships_returns_all_pages
     event_type_uri = "https://api.calendly.com/event_types/AAAAAAAAAAAAAAAA"
     token = "sNjq4TvMDfUHEl7zHRR0k0E1PCEJWvdi"
-    stub(path: "event_type_memberships?event_type=#{event_type_uri}", response: { body: fixture_file("event_type_memberships/list"), status: 200 })
-    stub(path: "event_type_memberships?event_type=#{event_type_uri}&page_token=#{token}", response: { body: fixture_file("event_type_memberships/list_page2"), status: 200 })
+    stub(path: "event_type_memberships?event_type=#{event_type_uri}", response: {body: fixture_file("event_type_memberships/list"), status: 200})
+    stub(path: "event_type_memberships?event_type=#{event_type_uri}&page_token=#{token}", response: {body: fixture_file("event_type_memberships/list_page2"), status: 200})
 
     memberships = client.event_types.list_all_memberships(event_type: event_type_uri)
 

--- a/test/calendlyr/resources/organizations_test.rb
+++ b/test/calendlyr/resources/organizations_test.rb
@@ -3,11 +3,23 @@
 require "test_helper"
 
 class OrganizationsResourceTest < Minitest::Test
+  def test_retrieve
+    organization_uuid = "012345678901234567890"
+    stub(path: "organizations/#{organization_uuid}", response: { body: fixture_file("organizations/retrieve"), status: 200 })
+
+    organization = client.organizations.retrieve(uuid: organization_uuid)
+
+    assert_equal Calendlyr::Organization, organization.class
+    assert_equal "https://api.calendly.com/organizations/012345678901234567890", organization.uri
+    assert_equal "Sales Team", organization.name
+    assert_equal "professional", organization.plan
+  end
+
   def test_invite
     organization_uuid = "ABCDABCDABCDABCD"
     email = "email@example.com"
-    response = {body: fixture_file("organizations/invite"), status: 201}
-    stub(method: :post, path: "organizations/#{organization_uuid}/invitations", body: {email: email}, response: response)
+    response = { body: fixture_file("organizations/invite"), status: 201 }
+    stub(method: :post, path: "organizations/#{organization_uuid}/invitations", body: { email: email }, response: response)
 
     invitation = client.organizations.invite(organization_uuid: organization_uuid, email: email)
 
@@ -17,7 +29,7 @@ class OrganizationsResourceTest < Minitest::Test
 
   def test_list_invitations
     organization_uuid = "abc123"
-    response = {body: fixture_file("organizations/list_invitations"), status: 200}
+    response = { body: fixture_file("organizations/list_invitations"), status: 200 }
     stub(path: "organizations/#{organization_uuid}/invitations", response: response)
     invitations = client.organizations.list_invitations(uuid: organization_uuid)
 
@@ -28,8 +40,8 @@ class OrganizationsResourceTest < Minitest::Test
   end
 
   def test_create_webhook
-    body = {url: "https://blah.foo/bar", events: ["invitee.created"], organization: client.organization.uri, scope: "user", user: client.me.uri}
-    stub(method: :post, path: "webhook_subscriptions", body: body, response: {body: fixture_file("webhooks/create"), status: 201})
+    body = { url: "https://blah.foo/bar", events: ["invitee.created"], organization: client.organization.uri, scope: "user", user: client.me.uri }
+    stub(method: :post, path: "webhook_subscriptions", body: body, response: { body: fixture_file("webhooks/create"), status: 201 })
 
     assert client.webhooks.create(**body)
   end
@@ -37,8 +49,8 @@ class OrganizationsResourceTest < Minitest::Test
   def test_retrieve_invitation
     invitation_uuid = "abc123"
 
-    stub(path: "organizations/#{client.organization.uuid}/invitations/#{invitation_uuid}", response: {body: fixture_file("organizations/retrieve_invitation"), status: 200})
-    stub(method: :delete, path: "organizations/#{client.organization.uuid}/invitations/#{invitation_uuid}", response: {body: fixture_file("organizations/revoke_invitation")})
+    stub(path: "organizations/#{client.organization.uuid}/invitations/#{invitation_uuid}", response: { body: fixture_file("organizations/retrieve_invitation"), status: 200 })
+    stub(method: :delete, path: "organizations/#{client.organization.uuid}/invitations/#{invitation_uuid}", response: { body: fixture_file("organizations/revoke_invitation") })
     invitation = client.organizations.retrieve_invitation(org_uuid: client.organization.uuid, uuid: invitation_uuid)
 
     assert_equal Calendlyr::Organizations::Invitation, invitation.class
@@ -51,7 +63,7 @@ class OrganizationsResourceTest < Minitest::Test
   def test_revoke_invitation
     organization_uuid = "abc123"
     invitation_uuid = "abc123"
-    response = {body: fixture_file("organizations/revoke_invitation")}
+    response = { body: fixture_file("organizations/revoke_invitation") }
     stub(method: :delete, path: "organizations/#{organization_uuid}/invitations/#{invitation_uuid}", response: response)
     assert client.organizations.revoke_invitation(org_uuid: organization_uuid, uuid: invitation_uuid)
   end
@@ -60,7 +72,7 @@ class OrganizationsResourceTest < Minitest::Test
   def test_list_memberships
     user_uri = "https://api.calendly.com/users/abc123"
     organization_uri = "https://api.calendly.com/organizations/abc123"
-    response = {body: fixture_file("organizations/list_memberships"), status: 200}
+    response = { body: fixture_file("organizations/list_memberships"), status: 200 }
     stub(path: "organization_memberships?user=#{user_uri}&organization=#{organization_uri}", response: response)
     memberships = client.organizations.list_memberships(user: user_uri, organization: organization_uri)
 
@@ -73,7 +85,7 @@ class OrganizationsResourceTest < Minitest::Test
   def test_activity_log_with_bare_org_uuid
     bare_uuid = "ORG-2"
     expanded = "https://api.calendly.com/organizations/#{bare_uuid}"
-    response = {body: fixture_file("activity_log/list"), status: 200}
+    response = { body: fixture_file("activity_log/list"), status: 200 }
     stub(path: "activity_log_entries?organization=#{expanded}", response: response)
 
     result = client.organizations.activity_log(organization: bare_uuid)
@@ -84,7 +96,7 @@ class OrganizationsResourceTest < Minitest::Test
   def test_list_memberships_with_bare_user_uuid
     bare_uuid = "USER-1"
     expanded = "https://api.calendly.com/users/#{bare_uuid}"
-    response = {body: fixture_file("organizations/list_memberships"), status: 200}
+    response = { body: fixture_file("organizations/list_memberships"), status: 200 }
     stub(path: "organization_memberships?user=#{expanded}", response: response)
 
     memberships = client.organizations.list_memberships(user: bare_uuid)
@@ -96,7 +108,7 @@ class OrganizationsResourceTest < Minitest::Test
   def test_list_memberships_with_bare_org_uuid
     bare_uuid = "ORG-1"
     expanded = "https://api.calendly.com/organizations/#{bare_uuid}"
-    response = {body: fixture_file("organizations/list_memberships"), status: 200}
+    response = { body: fixture_file("organizations/list_memberships"), status: 200 }
     stub(path: "organization_memberships?organization=#{expanded}", response: response)
 
     memberships = client.organizations.list_memberships(organization: bare_uuid)
@@ -107,9 +119,9 @@ class OrganizationsResourceTest < Minitest::Test
 
   def test_retrieve_membership
     membership_uuid = "abc123"
-    response = {body: fixture_file("organizations/retrieve_membership"), status: 200}
+    response = { body: fixture_file("organizations/retrieve_membership"), status: 200 }
     stub(path: "organization_memberships/#{membership_uuid}", response: response)
-    stub(path: "users/#{membership_uuid}", response: {body: fixture_file("users/retrieve"), status: 200})
+    stub(path: "users/#{membership_uuid}", response: { body: fixture_file("users/retrieve"), status: 200 })
     membership = client.organizations.retrieve_membership(uuid: membership_uuid)
 
     assert_equal Calendlyr::Organizations::Membership, membership.class
@@ -119,7 +131,7 @@ class OrganizationsResourceTest < Minitest::Test
 
   def test_remove_user
     membership_uuid = "abc123"
-    response = {body: fixture_file("organizations/remove_user")}
+    response = { body: fixture_file("organizations/remove_user") }
     stub(method: :delete, path: "organization_memberships/#{membership_uuid}", response: response)
     assert client.organizations.remove_user(uuid: membership_uuid)
   end
@@ -128,8 +140,8 @@ class OrganizationsResourceTest < Minitest::Test
     user_uri = "https://api.calendly.com/users/abc123"
     organization_uri = "https://api.calendly.com/organizations/abc123"
     token = "sNjq4TvMDfUHEl7zHRR0k0E1PCEJWvdi"
-    page1_response = {body: fixture_file("organizations/list_memberships"), status: 200}
-    page2_response = {body: fixture_file("organizations/list_memberships_page2"), status: 200}
+    page1_response = { body: fixture_file("organizations/list_memberships"), status: 200 }
+    page2_response = { body: fixture_file("organizations/list_memberships_page2"), status: 200 }
     stub(path: "organization_memberships?user=#{user_uri}&organization=#{organization_uri}", response: page1_response)
     stub(path: "organization_memberships?user=#{user_uri}&organization=#{organization_uri}&page_token=#{token}", response: page2_response)
 
@@ -143,8 +155,8 @@ class OrganizationsResourceTest < Minitest::Test
   def test_list_all_invitations_returns_all_pages
     organization_uuid = "abc123"
     token = "sNjq4TvMDfUHEl7zHRR0k0E1PCEJWvdi"
-    page1_response = {body: fixture_file("organizations/list_invitations"), status: 200}
-    page2_response = {body: fixture_file("organizations/list_invitations_page2"), status: 200}
+    page1_response = { body: fixture_file("organizations/list_invitations"), status: 200 }
+    page2_response = { body: fixture_file("organizations/list_invitations_page2"), status: 200 }
     stub(path: "organizations/#{organization_uuid}/invitations", response: page1_response)
     stub(path: "organizations/#{organization_uuid}/invitations?page_token=#{token}", response: page2_response)
 
@@ -159,8 +171,8 @@ class OrganizationsResourceTest < Minitest::Test
     bare_uuid = "ORG-2"
     expanded = "https://api.calendly.com/organizations/#{bare_uuid}"
     token = "sNjq4TvMDfUHEl7zHRR0k0E1PCEJWvdi"
-    page1_response = {body: fixture_file("activity_log/list"), status: 200}
-    page2_response = {body: fixture_file("activity_log/list_page2"), status: 200}
+    page1_response = { body: fixture_file("activity_log/list"), status: 200 }
+    page2_response = { body: fixture_file("activity_log/list_page2"), status: 200 }
     stub(path: "activity_log_entries?organization=#{expanded}", response: page1_response)
     stub(path: "activity_log_entries?organization=#{expanded}&page_token=#{token}", response: page2_response)
 

--- a/test/calendlyr/resources/organizations_test.rb
+++ b/test/calendlyr/resources/organizations_test.rb
@@ -5,7 +5,7 @@ require "test_helper"
 class OrganizationsResourceTest < Minitest::Test
   def test_retrieve
     organization_uuid = "012345678901234567890"
-    stub(path: "organizations/#{organization_uuid}", response: { body: fixture_file("organizations/retrieve"), status: 200 })
+    stub(path: "organizations/#{organization_uuid}", response: {body: fixture_file("organizations/retrieve"), status: 200})
 
     organization = client.organizations.retrieve(uuid: organization_uuid)
 
@@ -18,8 +18,8 @@ class OrganizationsResourceTest < Minitest::Test
   def test_invite
     organization_uuid = "ABCDABCDABCDABCD"
     email = "email@example.com"
-    response = { body: fixture_file("organizations/invite"), status: 201 }
-    stub(method: :post, path: "organizations/#{organization_uuid}/invitations", body: { email: email }, response: response)
+    response = {body: fixture_file("organizations/invite"), status: 201}
+    stub(method: :post, path: "organizations/#{organization_uuid}/invitations", body: {email: email}, response: response)
 
     invitation = client.organizations.invite(organization_uuid: organization_uuid, email: email)
 
@@ -29,7 +29,7 @@ class OrganizationsResourceTest < Minitest::Test
 
   def test_list_invitations
     organization_uuid = "abc123"
-    response = { body: fixture_file("organizations/list_invitations"), status: 200 }
+    response = {body: fixture_file("organizations/list_invitations"), status: 200}
     stub(path: "organizations/#{organization_uuid}/invitations", response: response)
     invitations = client.organizations.list_invitations(uuid: organization_uuid)
 
@@ -40,8 +40,8 @@ class OrganizationsResourceTest < Minitest::Test
   end
 
   def test_create_webhook
-    body = { url: "https://blah.foo/bar", events: ["invitee.created"], organization: client.organization.uri, scope: "user", user: client.me.uri }
-    stub(method: :post, path: "webhook_subscriptions", body: body, response: { body: fixture_file("webhooks/create"), status: 201 })
+    body = {url: "https://blah.foo/bar", events: ["invitee.created"], organization: client.organization.uri, scope: "user", user: client.me.uri}
+    stub(method: :post, path: "webhook_subscriptions", body: body, response: {body: fixture_file("webhooks/create"), status: 201})
 
     assert client.webhooks.create(**body)
   end
@@ -49,8 +49,8 @@ class OrganizationsResourceTest < Minitest::Test
   def test_retrieve_invitation
     invitation_uuid = "abc123"
 
-    stub(path: "organizations/#{client.organization.uuid}/invitations/#{invitation_uuid}", response: { body: fixture_file("organizations/retrieve_invitation"), status: 200 })
-    stub(method: :delete, path: "organizations/#{client.organization.uuid}/invitations/#{invitation_uuid}", response: { body: fixture_file("organizations/revoke_invitation") })
+    stub(path: "organizations/#{client.organization.uuid}/invitations/#{invitation_uuid}", response: {body: fixture_file("organizations/retrieve_invitation"), status: 200})
+    stub(method: :delete, path: "organizations/#{client.organization.uuid}/invitations/#{invitation_uuid}", response: {body: fixture_file("organizations/revoke_invitation")})
     invitation = client.organizations.retrieve_invitation(org_uuid: client.organization.uuid, uuid: invitation_uuid)
 
     assert_equal Calendlyr::Organizations::Invitation, invitation.class
@@ -63,7 +63,7 @@ class OrganizationsResourceTest < Minitest::Test
   def test_revoke_invitation
     organization_uuid = "abc123"
     invitation_uuid = "abc123"
-    response = { body: fixture_file("organizations/revoke_invitation") }
+    response = {body: fixture_file("organizations/revoke_invitation")}
     stub(method: :delete, path: "organizations/#{organization_uuid}/invitations/#{invitation_uuid}", response: response)
     assert client.organizations.revoke_invitation(org_uuid: organization_uuid, uuid: invitation_uuid)
   end
@@ -72,7 +72,7 @@ class OrganizationsResourceTest < Minitest::Test
   def test_list_memberships
     user_uri = "https://api.calendly.com/users/abc123"
     organization_uri = "https://api.calendly.com/organizations/abc123"
-    response = { body: fixture_file("organizations/list_memberships"), status: 200 }
+    response = {body: fixture_file("organizations/list_memberships"), status: 200}
     stub(path: "organization_memberships?user=#{user_uri}&organization=#{organization_uri}", response: response)
     memberships = client.organizations.list_memberships(user: user_uri, organization: organization_uri)
 
@@ -85,7 +85,7 @@ class OrganizationsResourceTest < Minitest::Test
   def test_activity_log_with_bare_org_uuid
     bare_uuid = "ORG-2"
     expanded = "https://api.calendly.com/organizations/#{bare_uuid}"
-    response = { body: fixture_file("activity_log/list"), status: 200 }
+    response = {body: fixture_file("activity_log/list"), status: 200}
     stub(path: "activity_log_entries?organization=#{expanded}", response: response)
 
     result = client.organizations.activity_log(organization: bare_uuid)
@@ -96,7 +96,7 @@ class OrganizationsResourceTest < Minitest::Test
   def test_list_memberships_with_bare_user_uuid
     bare_uuid = "USER-1"
     expanded = "https://api.calendly.com/users/#{bare_uuid}"
-    response = { body: fixture_file("organizations/list_memberships"), status: 200 }
+    response = {body: fixture_file("organizations/list_memberships"), status: 200}
     stub(path: "organization_memberships?user=#{expanded}", response: response)
 
     memberships = client.organizations.list_memberships(user: bare_uuid)
@@ -108,7 +108,7 @@ class OrganizationsResourceTest < Minitest::Test
   def test_list_memberships_with_bare_org_uuid
     bare_uuid = "ORG-1"
     expanded = "https://api.calendly.com/organizations/#{bare_uuid}"
-    response = { body: fixture_file("organizations/list_memberships"), status: 200 }
+    response = {body: fixture_file("organizations/list_memberships"), status: 200}
     stub(path: "organization_memberships?organization=#{expanded}", response: response)
 
     memberships = client.organizations.list_memberships(organization: bare_uuid)
@@ -119,9 +119,9 @@ class OrganizationsResourceTest < Minitest::Test
 
   def test_retrieve_membership
     membership_uuid = "abc123"
-    response = { body: fixture_file("organizations/retrieve_membership"), status: 200 }
+    response = {body: fixture_file("organizations/retrieve_membership"), status: 200}
     stub(path: "organization_memberships/#{membership_uuid}", response: response)
-    stub(path: "users/#{membership_uuid}", response: { body: fixture_file("users/retrieve"), status: 200 })
+    stub(path: "users/#{membership_uuid}", response: {body: fixture_file("users/retrieve"), status: 200})
     membership = client.organizations.retrieve_membership(uuid: membership_uuid)
 
     assert_equal Calendlyr::Organizations::Membership, membership.class
@@ -131,7 +131,7 @@ class OrganizationsResourceTest < Minitest::Test
 
   def test_remove_user
     membership_uuid = "abc123"
-    response = { body: fixture_file("organizations/remove_user") }
+    response = {body: fixture_file("organizations/remove_user")}
     stub(method: :delete, path: "organization_memberships/#{membership_uuid}", response: response)
     assert client.organizations.remove_user(uuid: membership_uuid)
   end
@@ -140,8 +140,8 @@ class OrganizationsResourceTest < Minitest::Test
     user_uri = "https://api.calendly.com/users/abc123"
     organization_uri = "https://api.calendly.com/organizations/abc123"
     token = "sNjq4TvMDfUHEl7zHRR0k0E1PCEJWvdi"
-    page1_response = { body: fixture_file("organizations/list_memberships"), status: 200 }
-    page2_response = { body: fixture_file("organizations/list_memberships_page2"), status: 200 }
+    page1_response = {body: fixture_file("organizations/list_memberships"), status: 200}
+    page2_response = {body: fixture_file("organizations/list_memberships_page2"), status: 200}
     stub(path: "organization_memberships?user=#{user_uri}&organization=#{organization_uri}", response: page1_response)
     stub(path: "organization_memberships?user=#{user_uri}&organization=#{organization_uri}&page_token=#{token}", response: page2_response)
 
@@ -155,8 +155,8 @@ class OrganizationsResourceTest < Minitest::Test
   def test_list_all_invitations_returns_all_pages
     organization_uuid = "abc123"
     token = "sNjq4TvMDfUHEl7zHRR0k0E1PCEJWvdi"
-    page1_response = { body: fixture_file("organizations/list_invitations"), status: 200 }
-    page2_response = { body: fixture_file("organizations/list_invitations_page2"), status: 200 }
+    page1_response = {body: fixture_file("organizations/list_invitations"), status: 200}
+    page2_response = {body: fixture_file("organizations/list_invitations_page2"), status: 200}
     stub(path: "organizations/#{organization_uuid}/invitations", response: page1_response)
     stub(path: "organizations/#{organization_uuid}/invitations?page_token=#{token}", response: page2_response)
 
@@ -171,8 +171,8 @@ class OrganizationsResourceTest < Minitest::Test
     bare_uuid = "ORG-2"
     expanded = "https://api.calendly.com/organizations/#{bare_uuid}"
     token = "sNjq4TvMDfUHEl7zHRR0k0E1PCEJWvdi"
-    page1_response = { body: fixture_file("activity_log/list"), status: 200 }
-    page2_response = { body: fixture_file("activity_log/list_page2"), status: 200 }
+    page1_response = {body: fixture_file("activity_log/list"), status: 200}
+    page2_response = {body: fixture_file("activity_log/list_page2"), status: 200}
     stub(path: "activity_log_entries?organization=#{expanded}", response: page1_response)
     stub(path: "activity_log_entries?organization=#{expanded}&page_token=#{token}", response: page2_response)
 

--- a/test/calendlyr/resources/outgoing_communications_test.rb
+++ b/test/calendlyr/resources/outgoing_communications_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class OutgoingCommunicationsResourceTest < Minitest::Test
+  def test_list
+    organization_uri = "https://api.calendly.com/organizations/abc123"
+    stub(path: "outgoing_communications?organization=#{organization_uri}", response: { body: fixture_file("outgoing_communications/list"), status: 200 })
+
+    communications = client.outgoing_communications.list(organization: organization_uri)
+
+    assert_equal Calendlyr::Collection, communications.class
+    assert_equal Calendlyr::OutgoingCommunication, communications.data.first.class
+    assert_equal 1, communications.data.count
+    assert_equal "sNjq4TvMDfUHEl7zHRR0k0E1PCEJWvdi", communications.next_page_token
+    assert_equal "sms", communications.data.first.type
+  end
+
+  def test_list_with_bare_org_uuid
+    bare_uuid = "abc123"
+    expanded = "https://api.calendly.com/organizations/#{bare_uuid}"
+    stub(path: "outgoing_communications?organization=#{expanded}", response: { body: fixture_file("outgoing_communications/list"), status: 200 })
+
+    communications = client.outgoing_communications.list(organization: bare_uuid)
+
+    assert_equal Calendlyr::Collection, communications.class
+    assert_equal 1, communications.data.count
+  end
+
+  def test_list_all_returns_all_pages
+    organization_uri = "https://api.calendly.com/organizations/abc123"
+    token = "sNjq4TvMDfUHEl7zHRR0k0E1PCEJWvdi"
+    stub(path: "outgoing_communications?organization=#{organization_uri}", response: { body: fixture_file("outgoing_communications/list"), status: 200 })
+    stub(path: "outgoing_communications?organization=#{organization_uri}&page_token=#{token}", response: { body: fixture_file("outgoing_communications/list_page2"), status: 200 })
+
+    communications = client.outgoing_communications.list_all(organization: organization_uri)
+
+    assert_equal Array, communications.class
+    assert_equal 2, communications.size
+    assert_equal Calendlyr::OutgoingCommunication, communications.first.class
+  end
+end

--- a/test/calendlyr/resources/outgoing_communications_test.rb
+++ b/test/calendlyr/resources/outgoing_communications_test.rb
@@ -5,7 +5,7 @@ require "test_helper"
 class OutgoingCommunicationsResourceTest < Minitest::Test
   def test_list
     organization_uri = "https://api.calendly.com/organizations/abc123"
-    stub(path: "outgoing_communications?organization=#{organization_uri}", response: { body: fixture_file("outgoing_communications/list"), status: 200 })
+    stub(path: "outgoing_communications?organization=#{organization_uri}", response: {body: fixture_file("outgoing_communications/list"), status: 200})
 
     communications = client.outgoing_communications.list(organization: organization_uri)
 
@@ -19,7 +19,7 @@ class OutgoingCommunicationsResourceTest < Minitest::Test
   def test_list_with_bare_org_uuid
     bare_uuid = "abc123"
     expanded = "https://api.calendly.com/organizations/#{bare_uuid}"
-    stub(path: "outgoing_communications?organization=#{expanded}", response: { body: fixture_file("outgoing_communications/list"), status: 200 })
+    stub(path: "outgoing_communications?organization=#{expanded}", response: {body: fixture_file("outgoing_communications/list"), status: 200})
 
     communications = client.outgoing_communications.list(organization: bare_uuid)
 
@@ -30,8 +30,8 @@ class OutgoingCommunicationsResourceTest < Minitest::Test
   def test_list_all_returns_all_pages
     organization_uri = "https://api.calendly.com/organizations/abc123"
     token = "sNjq4TvMDfUHEl7zHRR0k0E1PCEJWvdi"
-    stub(path: "outgoing_communications?organization=#{organization_uri}", response: { body: fixture_file("outgoing_communications/list"), status: 200 })
-    stub(path: "outgoing_communications?organization=#{organization_uri}&page_token=#{token}", response: { body: fixture_file("outgoing_communications/list_page2"), status: 200 })
+    stub(path: "outgoing_communications?organization=#{organization_uri}", response: {body: fixture_file("outgoing_communications/list"), status: 200})
+    stub(path: "outgoing_communications?organization=#{organization_uri}&page_token=#{token}", response: {body: fixture_file("outgoing_communications/list_page2"), status: 200})
 
     communications = client.outgoing_communications.list_all(organization: organization_uri)
 

--- a/test/calendlyr/resources/scheduling_links_test.rb
+++ b/test/calendlyr/resources/scheduling_links_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class SchedulingLinksResourceTest < Minitest::Test
+  def test_create
+    event_type_uri = "https://api.calendly.com/event_types/GBGBDCAADAEDCRZ2"
+    body = { max_event_count: 1, owner: event_type_uri, owner_type: "EventType" }
+    stub(method: :post, path: "scheduling_links", body: body, response: { body: fixture_file("scheduling_links/create"), status: 201 })
+
+    link = client.scheduling_links.create(owner: event_type_uri)
+
+    assert_equal Calendlyr::SchedulingLink, link.class
+    assert_equal "https://calendly.com/d/abcd-brv8/15-minute-meeting", link.booking_url
+    assert_equal event_type_uri, link.owner
+    assert_equal "EventType", link.owner_type
+  end
+
+  def test_create_with_bare_event_type_uuid
+    bare_uuid = "GBGBDCAADAEDCRZ2"
+    expanded = "https://api.calendly.com/event_types/#{bare_uuid}"
+    body = { max_event_count: 1, owner: expanded, owner_type: "EventType" }
+    stub(method: :post, path: "scheduling_links", body: body, response: { body: fixture_file("scheduling_links/create"), status: 201 })
+
+    link = client.scheduling_links.create(owner: bare_uuid)
+
+    assert_equal Calendlyr::SchedulingLink, link.class
+    assert_equal "https://calendly.com/d/abcd-brv8/15-minute-meeting", link.booking_url
+  end
+
+  def test_create_with_custom_max_event_count
+    event_type_uri = "https://api.calendly.com/event_types/GBGBDCAADAEDCRZ2"
+    body = { max_event_count: 5, owner: event_type_uri, owner_type: "EventType" }
+    stub(method: :post, path: "scheduling_links", body: body, response: { body: fixture_file("scheduling_links/create"), status: 201 })
+
+    link = client.scheduling_links.create(owner: event_type_uri, max_event_count: 5)
+
+    assert_equal Calendlyr::SchedulingLink, link.class
+  end
+end

--- a/test/calendlyr/resources/scheduling_links_test.rb
+++ b/test/calendlyr/resources/scheduling_links_test.rb
@@ -5,8 +5,8 @@ require "test_helper"
 class SchedulingLinksResourceTest < Minitest::Test
   def test_create
     event_type_uri = "https://api.calendly.com/event_types/GBGBDCAADAEDCRZ2"
-    body = { max_event_count: 1, owner: event_type_uri, owner_type: "EventType" }
-    stub(method: :post, path: "scheduling_links", body: body, response: { body: fixture_file("scheduling_links/create"), status: 201 })
+    body = {max_event_count: 1, owner: event_type_uri, owner_type: "EventType"}
+    stub(method: :post, path: "scheduling_links", body: body, response: {body: fixture_file("scheduling_links/create"), status: 201})
 
     link = client.scheduling_links.create(owner: event_type_uri)
 
@@ -19,8 +19,8 @@ class SchedulingLinksResourceTest < Minitest::Test
   def test_create_with_bare_event_type_uuid
     bare_uuid = "GBGBDCAADAEDCRZ2"
     expanded = "https://api.calendly.com/event_types/#{bare_uuid}"
-    body = { max_event_count: 1, owner: expanded, owner_type: "EventType" }
-    stub(method: :post, path: "scheduling_links", body: body, response: { body: fixture_file("scheduling_links/create"), status: 201 })
+    body = {max_event_count: 1, owner: expanded, owner_type: "EventType"}
+    stub(method: :post, path: "scheduling_links", body: body, response: {body: fixture_file("scheduling_links/create"), status: 201})
 
     link = client.scheduling_links.create(owner: bare_uuid)
 
@@ -30,8 +30,8 @@ class SchedulingLinksResourceTest < Minitest::Test
 
   def test_create_with_custom_max_event_count
     event_type_uri = "https://api.calendly.com/event_types/GBGBDCAADAEDCRZ2"
-    body = { max_event_count: 5, owner: event_type_uri, owner_type: "EventType" }
-    stub(method: :post, path: "scheduling_links", body: body, response: { body: fixture_file("scheduling_links/create"), status: 201 })
+    body = {max_event_count: 5, owner: event_type_uri, owner_type: "EventType"}
+    stub(method: :post, path: "scheduling_links", body: body, response: {body: fixture_file("scheduling_links/create"), status: 201})
 
     link = client.scheduling_links.create(owner: event_type_uri, max_event_count: 5)
 

--- a/test/calendlyr/resources/webhooks_test.rb
+++ b/test/calendlyr/resources/webhooks_test.rb
@@ -6,7 +6,7 @@ class WebhooksResourceTest < Minitest::Test
   def test_list
     organization_uri = "https://api.calendly.com/organizations/abc123"
     scope = "user"
-    response = {body: fixture_file("webhooks/list"), status: 200}
+    response = { body: fixture_file("webhooks/list"), status: 200 }
     stub(path: "webhook_subscriptions?organization=#{organization_uri}&scope=#{scope}", response: response)
     webhooks = client.webhooks.list(organization: organization_uri, scope: scope)
 
@@ -17,8 +17,8 @@ class WebhooksResourceTest < Minitest::Test
   end
 
   def test_create
-    body = {url: "https://blah.foo/bar", events: ["invitee.created"], organization: "https://api.calendly.com/organizations/abc123", scope: "user", user: "https://api.calendly.com/users/abc123"}
-    stub(method: :post, path: "webhook_subscriptions", body: body, response: {body: fixture_file("webhooks/create"), status: 201})
+    body = { url: "https://blah.foo/bar", events: ["invitee.created"], organization: "https://api.calendly.com/organizations/abc123", scope: "user", user: "https://api.calendly.com/users/abc123" }
+    stub(method: :post, path: "webhook_subscriptions", body: body, response: { body: fixture_file("webhooks/create"), status: 201 })
 
     assert client.webhooks.create(**body)
     assert client.organization.create_webhook(**body)
@@ -26,8 +26,8 @@ class WebhooksResourceTest < Minitest::Test
 
   def test_retrieve
     webhook_uuid = "abc123"
-    stub(path: "webhook_subscriptions/#{webhook_uuid}", response: {body: fixture_file("webhooks/retrieve"), status: 200})
-    stub(path: "users/abc123", response: {body: fixture_file("users/retrieve"), status: 200})
+    stub(path: "webhook_subscriptions/#{webhook_uuid}", response: { body: fixture_file("webhooks/retrieve"), status: 200 })
+    stub(path: "users/abc123", response: { body: fixture_file("users/retrieve"), status: 200 })
     webhook = client.webhooks.retrieve(webhook_uuid: webhook_uuid)
 
     assert_equal Calendlyr::Webhooks::Subscription, webhook.class
@@ -41,7 +41,7 @@ class WebhooksResourceTest < Minitest::Test
     bare_uuid = "abc123"
     expanded = "https://api.calendly.com/organizations/#{bare_uuid}"
     scope = "organization"
-    response = {body: fixture_file("webhooks/list"), status: 200}
+    response = { body: fixture_file("webhooks/list"), status: 200 }
     stub(path: "webhook_subscriptions?organization=#{expanded}&scope=#{scope}", response: response)
 
     webhooks = client.webhooks.list(organization: bare_uuid, scope: scope)
@@ -53,8 +53,8 @@ class WebhooksResourceTest < Minitest::Test
   def test_create_with_bare_org_uuid
     bare_uuid = "abc123"
     expanded = "https://api.calendly.com/organizations/#{bare_uuid}"
-    body = {url: "https://blah.foo/bar", events: ["invitee.created"], organization: expanded, scope: "user", user: "https://api.calendly.com/users/abc123"}
-    stub(method: :post, path: "webhook_subscriptions", body: body, response: {body: fixture_file("webhooks/create"), status: 201})
+    body = { url: "https://blah.foo/bar", events: ["invitee.created"], organization: expanded, scope: "user", user: "https://api.calendly.com/users/abc123" }
+    stub(method: :post, path: "webhook_subscriptions", body: body, response: { body: fixture_file("webhooks/create"), status: 201 })
 
     result = client.webhooks.create(url: "https://blah.foo/bar", events: ["invitee.created"], organization: bare_uuid, scope: "user", user: "https://api.calendly.com/users/abc123")
 
@@ -63,7 +63,7 @@ class WebhooksResourceTest < Minitest::Test
 
   def test_delete
     webhook_uuid = "abc123"
-    response = {body: fixture_file("webhooks/delete")}
+    response = { body: fixture_file("webhooks/delete") }
     stub(method: :delete, path: "webhook_subscriptions/#{webhook_uuid}", response: response)
     assert client.webhooks.delete(webhook_uuid: webhook_uuid)
   end
@@ -72,8 +72,8 @@ class WebhooksResourceTest < Minitest::Test
     organization_uri = "https://api.calendly.com/organizations/abc123"
     scope = "user"
     token = "sNjq4TvMDfUHEl7zHRR0k0E1PCEJWvdi"
-    page1_response = {body: fixture_file("webhooks/list"), status: 200}
-    page2_response = {body: fixture_file("webhooks/list_page2"), status: 200}
+    page1_response = { body: fixture_file("webhooks/list"), status: 200 }
+    page2_response = { body: fixture_file("webhooks/list_page2"), status: 200 }
     stub(path: "webhook_subscriptions?organization=#{organization_uri}&scope=#{scope}", response: page1_response)
     stub(path: "webhook_subscriptions?organization=#{organization_uri}&scope=#{scope}&page_token=#{token}", response: page2_response)
 
@@ -82,5 +82,31 @@ class WebhooksResourceTest < Minitest::Test
     assert_equal Array, webhooks.class
     assert_equal 2, webhooks.size
     assert_equal Calendlyr::Webhooks::Subscription, webhooks.first.class
+  end
+
+  def test_sample
+    organization_uri = "https://api.calendly.com/organizations/abc123"
+    event = "invitee.created"
+    scope = "organization"
+    stub(path: "sample_webhook_data?event=#{event}&organization=#{organization_uri}&scope=#{scope}", response: { body: fixture_file("webhooks/sample"), status: 200 })
+
+    result = client.webhooks.sample(event: event, organization: organization_uri, scope: scope)
+
+    assert_equal Hash, result.class
+    assert_equal "invitee.created", result["event"]
+    assert result.key?("payload")
+  end
+
+  def test_sample_with_bare_org_uuid
+    bare_uuid = "abc123"
+    expanded = "https://api.calendly.com/organizations/#{bare_uuid}"
+    event = "invitee.created"
+    scope = "organization"
+    stub(path: "sample_webhook_data?event=#{event}&organization=#{expanded}&scope=#{scope}", response: { body: fixture_file("webhooks/sample"), status: 200 })
+
+    result = client.webhooks.sample(event: event, organization: bare_uuid, scope: scope)
+
+    assert_equal Hash, result.class
+    assert_equal "invitee.created", result["event"]
   end
 end

--- a/test/calendlyr/resources/webhooks_test.rb
+++ b/test/calendlyr/resources/webhooks_test.rb
@@ -6,7 +6,7 @@ class WebhooksResourceTest < Minitest::Test
   def test_list
     organization_uri = "https://api.calendly.com/organizations/abc123"
     scope = "user"
-    response = { body: fixture_file("webhooks/list"), status: 200 }
+    response = {body: fixture_file("webhooks/list"), status: 200}
     stub(path: "webhook_subscriptions?organization=#{organization_uri}&scope=#{scope}", response: response)
     webhooks = client.webhooks.list(organization: organization_uri, scope: scope)
 
@@ -17,8 +17,8 @@ class WebhooksResourceTest < Minitest::Test
   end
 
   def test_create
-    body = { url: "https://blah.foo/bar", events: ["invitee.created"], organization: "https://api.calendly.com/organizations/abc123", scope: "user", user: "https://api.calendly.com/users/abc123" }
-    stub(method: :post, path: "webhook_subscriptions", body: body, response: { body: fixture_file("webhooks/create"), status: 201 })
+    body = {url: "https://blah.foo/bar", events: ["invitee.created"], organization: "https://api.calendly.com/organizations/abc123", scope: "user", user: "https://api.calendly.com/users/abc123"}
+    stub(method: :post, path: "webhook_subscriptions", body: body, response: {body: fixture_file("webhooks/create"), status: 201})
 
     assert client.webhooks.create(**body)
     assert client.organization.create_webhook(**body)
@@ -26,8 +26,8 @@ class WebhooksResourceTest < Minitest::Test
 
   def test_retrieve
     webhook_uuid = "abc123"
-    stub(path: "webhook_subscriptions/#{webhook_uuid}", response: { body: fixture_file("webhooks/retrieve"), status: 200 })
-    stub(path: "users/abc123", response: { body: fixture_file("users/retrieve"), status: 200 })
+    stub(path: "webhook_subscriptions/#{webhook_uuid}", response: {body: fixture_file("webhooks/retrieve"), status: 200})
+    stub(path: "users/abc123", response: {body: fixture_file("users/retrieve"), status: 200})
     webhook = client.webhooks.retrieve(webhook_uuid: webhook_uuid)
 
     assert_equal Calendlyr::Webhooks::Subscription, webhook.class
@@ -41,7 +41,7 @@ class WebhooksResourceTest < Minitest::Test
     bare_uuid = "abc123"
     expanded = "https://api.calendly.com/organizations/#{bare_uuid}"
     scope = "organization"
-    response = { body: fixture_file("webhooks/list"), status: 200 }
+    response = {body: fixture_file("webhooks/list"), status: 200}
     stub(path: "webhook_subscriptions?organization=#{expanded}&scope=#{scope}", response: response)
 
     webhooks = client.webhooks.list(organization: bare_uuid, scope: scope)
@@ -53,8 +53,8 @@ class WebhooksResourceTest < Minitest::Test
   def test_create_with_bare_org_uuid
     bare_uuid = "abc123"
     expanded = "https://api.calendly.com/organizations/#{bare_uuid}"
-    body = { url: "https://blah.foo/bar", events: ["invitee.created"], organization: expanded, scope: "user", user: "https://api.calendly.com/users/abc123" }
-    stub(method: :post, path: "webhook_subscriptions", body: body, response: { body: fixture_file("webhooks/create"), status: 201 })
+    body = {url: "https://blah.foo/bar", events: ["invitee.created"], organization: expanded, scope: "user", user: "https://api.calendly.com/users/abc123"}
+    stub(method: :post, path: "webhook_subscriptions", body: body, response: {body: fixture_file("webhooks/create"), status: 201})
 
     result = client.webhooks.create(url: "https://blah.foo/bar", events: ["invitee.created"], organization: bare_uuid, scope: "user", user: "https://api.calendly.com/users/abc123")
 
@@ -63,7 +63,7 @@ class WebhooksResourceTest < Minitest::Test
 
   def test_delete
     webhook_uuid = "abc123"
-    response = { body: fixture_file("webhooks/delete") }
+    response = {body: fixture_file("webhooks/delete")}
     stub(method: :delete, path: "webhook_subscriptions/#{webhook_uuid}", response: response)
     assert client.webhooks.delete(webhook_uuid: webhook_uuid)
   end
@@ -72,8 +72,8 @@ class WebhooksResourceTest < Minitest::Test
     organization_uri = "https://api.calendly.com/organizations/abc123"
     scope = "user"
     token = "sNjq4TvMDfUHEl7zHRR0k0E1PCEJWvdi"
-    page1_response = { body: fixture_file("webhooks/list"), status: 200 }
-    page2_response = { body: fixture_file("webhooks/list_page2"), status: 200 }
+    page1_response = {body: fixture_file("webhooks/list"), status: 200}
+    page2_response = {body: fixture_file("webhooks/list_page2"), status: 200}
     stub(path: "webhook_subscriptions?organization=#{organization_uri}&scope=#{scope}", response: page1_response)
     stub(path: "webhook_subscriptions?organization=#{organization_uri}&scope=#{scope}&page_token=#{token}", response: page2_response)
 
@@ -88,7 +88,7 @@ class WebhooksResourceTest < Minitest::Test
     organization_uri = "https://api.calendly.com/organizations/abc123"
     event = "invitee.created"
     scope = "organization"
-    stub(path: "sample_webhook_data?event=#{event}&organization=#{organization_uri}&scope=#{scope}", response: { body: fixture_file("webhooks/sample"), status: 200 })
+    stub(path: "sample_webhook_data?event=#{event}&organization=#{organization_uri}&scope=#{scope}", response: {body: fixture_file("webhooks/sample"), status: 200})
 
     result = client.webhooks.sample(event: event, organization: organization_uri, scope: scope)
 
@@ -102,7 +102,7 @@ class WebhooksResourceTest < Minitest::Test
     expanded = "https://api.calendly.com/organizations/#{bare_uuid}"
     event = "invitee.created"
     scope = "organization"
-    stub(path: "sample_webhook_data?event=#{event}&organization=#{expanded}&scope=#{scope}", response: { body: fixture_file("webhooks/sample"), status: 200 })
+    stub(path: "sample_webhook_data?event=#{event}&organization=#{expanded}&scope=#{scope}", response: {body: fixture_file("webhooks/sample"), status: 200})
 
     result = client.webhooks.sample(event: event, organization: bare_uuid, scope: scope)
 

--- a/test/fixtures/event_type_available_times/list.json
+++ b/test/fixtures/event_type_available_times/list.json
@@ -1,0 +1,10 @@
+{
+  "collection": [
+    {
+      "status": "available",
+      "invitees_remaining": 2,
+      "start_time": "2020-01-02T20:00:00.000000Z",
+      "scheduling_url": "https://calendly.com/acmesales/discovery-call/2020-01-02T20:00:00Z?month=2020-01&date=2020-01-02"
+    }
+  ]
+}

--- a/test/fixtures/event_type_memberships/list.json
+++ b/test/fixtures/event_type_memberships/list.json
@@ -1,0 +1,43 @@
+{
+  "collection": [
+    {
+      "uri": "https://api.calendly.com/event_type_memberships/AAAAAAAAAAAAAAAA",
+      "event_type": {
+        "uri": "https://api.calendly.com/event_types/AAAAAAAAAAAAAAAA",
+        "name": "15 Minute Meeting",
+        "active": true,
+        "slug": "acmesales",
+        "scheduling_url": "https://calendly.com/acmesales",
+        "duration": 30,
+        "kind": "solo",
+        "pooling_type": "round_robin",
+        "type": "StandardEventType",
+        "color": "#fff200",
+        "created_at": "2019-01-02T03:04:05.678123Z",
+        "updated_at": "2019-08-07T06:05:04.321123Z"
+      },
+      "member": {
+        "uri": "https://api.calendly.com/users/AAAAAAAAAAAAAAAA",
+        "name": "John Doe",
+        "slug": "acmesales",
+        "email": "test@example.com",
+        "scheduling_url": "https://calendly.com/acmesales",
+        "timezone": "America/New_York",
+        "avatar_url": "https://01234567890.cloudfront.net/uploads/user/avatar/0123456/a1b2c3d4.png",
+        "created_at": "2019-01-02T03:04:05.678123Z",
+        "updated_at": "2019-08-07T06:05:04.321123Z",
+        "current_organization": "https://api.calendly.com/organizations/AAAAAAAAAAAAAAAA",
+        "resource_type": "User"
+      },
+      "updated_at": "2019-01-02T03:04:05.678123Z",
+      "created_at": "2019-01-02T03:04:05.678123Z"
+    }
+  ],
+  "pagination": {
+    "count": 20,
+    "next_page": "https://api.calendly.com/event_type_memberships?count=1&page_token=sNjq4TvMDfUHEl7zHRR0k0E1PCEJWvdi",
+    "previous_page": "https://api.calendly.com/event_type_memberships?count=1&page_token=VJs2rfDYeY8ahZpq0QI1O114LJkNjd7H",
+    "next_page_token": "sNjq4TvMDfUHEl7zHRR0k0E1PCEJWvdi",
+    "previous_page_token": "VJs2rfDYeY8ahZpq0QI1O114LJkNjd7H"
+  }
+}

--- a/test/fixtures/event_type_memberships/list_page2.json
+++ b/test/fixtures/event_type_memberships/list_page2.json
@@ -1,0 +1,33 @@
+{
+  "collection": [
+    {
+      "uri": "https://api.calendly.com/event_type_memberships/BBBBBBBBBBBBBBBB",
+      "event_type": {
+        "uri": "https://api.calendly.com/event_types/AAAAAAAAAAAAAAAA",
+        "name": "15 Minute Meeting",
+        "active": true,
+        "slug": "acmesales",
+        "scheduling_url": "https://calendly.com/acmesales",
+        "duration": 30,
+        "kind": "solo"
+      },
+      "member": {
+        "uri": "https://api.calendly.com/users/BBBBBBBBBBBBBBBB",
+        "name": "Jane Doe",
+        "slug": "jane",
+        "email": "jane@example.com",
+        "scheduling_url": "https://calendly.com/jane",
+        "timezone": "America/Chicago",
+        "created_at": "2019-01-02T03:04:05.678123Z",
+        "updated_at": "2019-08-07T06:05:04.321123Z",
+        "current_organization": "https://api.calendly.com/organizations/AAAAAAAAAAAAAAAA",
+        "resource_type": "User"
+      },
+      "updated_at": "2019-01-02T03:04:05.678123Z",
+      "created_at": "2019-01-02T03:04:05.678123Z"
+    }
+  ],
+  "pagination": {
+    "count": 1
+  }
+}

--- a/test/fixtures/organizations/retrieve.json
+++ b/test/fixtures/organizations/retrieve.json
@@ -1,0 +1,11 @@
+{
+  "resource": {
+    "uri": "https://api.calendly.com/organizations/012345678901234567890",
+    "kind": "multiple",
+    "name": "Sales Team",
+    "plan": "professional",
+    "stage": "paid",
+    "created_at": "2019-01-02T03:04:05.678123Z",
+    "updated_at": "2019-08-07T06:05:04.321123Z"
+  }
+}

--- a/test/fixtures/outgoing_communications/list.json
+++ b/test/fixtures/outgoing_communications/list.json
@@ -1,0 +1,24 @@
+{
+  "collection": [
+    {
+      "type": "sms",
+      "to": "+14047549876",
+      "from": "+14042916667",
+      "subject": "",
+      "body": "Your scheduled event is coming up.",
+      "sender_uri": "https://api.calendly.com/users/AAAAAAAAAAAAAAAA",
+      "sender_email": "user@example.com",
+      "event_type_uri": "https://api.calendly.com/event_types/AAAAAAAAAAAAAAAA",
+      "event_uri": "https://api.calendly.com/scheduled_events/ABCDABCDABCDABCD",
+      "sent_at": "2023-09-24T11:12:13.145Z",
+      "created_at": "2023-09-24T11:12:13.145Z",
+      "scheduling_url": "https://calendly.com/event/name"
+    }
+  ],
+  "pagination": {
+    "count": 1,
+    "next_page": "https://api.calendly.com/outgoing_communications?count=1&page_token=sNjq4TvMDfUHEl7zHRR0k0E1PCEJWvdi",
+    "next_page_token": "sNjq4TvMDfUHEl7zHRR0k0E1PCEJWvdi",
+    "previous_page_token": null
+  }
+}

--- a/test/fixtures/outgoing_communications/list_page2.json
+++ b/test/fixtures/outgoing_communications/list_page2.json
@@ -1,0 +1,21 @@
+{
+  "collection": [
+    {
+      "type": "email",
+      "to": "user2@example.com",
+      "from": "noreply@calendly.com",
+      "subject": "Reminder: upcoming event",
+      "body": "Your event is tomorrow.",
+      "sender_uri": "https://api.calendly.com/users/BBBBBBBBBBBBBBBB",
+      "sender_email": "user2@example.com",
+      "event_type_uri": "https://api.calendly.com/event_types/BBBBBBBBBBBBBBBB",
+      "event_uri": "https://api.calendly.com/scheduled_events/BBBBBBBBBBBBBBBB",
+      "sent_at": "2023-09-25T11:12:13.145Z",
+      "created_at": "2023-09-25T11:12:13.145Z",
+      "scheduling_url": "https://calendly.com/event/other"
+    }
+  ],
+  "pagination": {
+    "count": 1
+  }
+}

--- a/test/fixtures/scheduling_links/create.json
+++ b/test/fixtures/scheduling_links/create.json
@@ -1,0 +1,7 @@
+{
+  "resource": {
+    "booking_url": "https://calendly.com/d/abcd-brv8/15-minute-meeting",
+    "owner": "https://api.calendly.com/event_types/GBGBDCAADAEDCRZ2",
+    "owner_type": "EventType"
+  }
+}

--- a/test/fixtures/webhooks/sample.json
+++ b/test/fixtures/webhooks/sample.json
@@ -1,0 +1,66 @@
+{
+  "event": "invitee.created",
+  "payload": {
+    "event_type": {
+      "uuid": "AAAAAAAAAAAAAAAA",
+      "kind": "One-on-One",
+      "slug": "acmesales",
+      "name": "15 Minute Meeting",
+      "duration": 15,
+      "owner": {
+        "type": "User",
+        "uuid": "AAAAAAAAAAAAAAAA"
+      }
+    },
+    "event": {
+      "uuid": "AAAAAAAAAAAAAAAA",
+      "assigned_to": ["Jane Sample Data"],
+      "extended_assigned_to": [
+        {
+          "name": "Jane Sample Data",
+          "email": "user@example.com",
+          "primary": false
+        }
+      ],
+      "start_time": "2020-01-02T20:00:00.000000Z",
+      "start_time_pretty": "12:00pm - Friday, January 3, 2020",
+      "invitees_counter": {
+        "total": 0,
+        "active": 0,
+        "limit": 1
+      },
+      "created_at": "2019-12-24T05:13:04.000000Z",
+      "location": "",
+      "canceled": false
+    },
+    "invitee": {
+      "uuid": "AAAAAAAAAAAAAAAA",
+      "first_name": "Joe",
+      "last_name": "Sample Data",
+      "name": "Joe Sample Data",
+      "email": "not-a-real-person@example.com",
+      "text_reminder_number": null,
+      "timezone": "UTC",
+      "created_at": "2019-12-24T05:13:04.000000Z",
+      "is_reschedule": false,
+      "payments": [],
+      "canceled": false,
+      "scheduling_method": null,
+      "rescheduled_from": null
+    },
+    "questions_and_answers": [],
+    "questions_and_responses": {},
+    "tracking": {
+      "utm_campaign": null,
+      "utm_source": null,
+      "utm_medium": null,
+      "utm_content": null,
+      "utm_term": null,
+      "salesforce_uuid": null
+    },
+    "old_event": null,
+    "old_invitee": null,
+    "new_event": null,
+    "new_invitee": null
+  }
+}


### PR DESCRIPTION
## Summary

- Re-implement 5 endpoints incorrectly removed in v0.9.0 + add `organizations.retrieve`
- Full test coverage for all new endpoints (Minitest + webmock + JSON fixtures)
- Version bump to 1.0.0 — signals complete Calendly API v2 coverage

## Endpoints added

| Endpoint | Method |
|----------|--------|
| `GET /event_type_available_times` | `event_types.list_available_times` |
| `GET /event_type_memberships` | `event_types.list_memberships` / `list_all_memberships` |
| `POST /scheduling_links` | `scheduling_links.create` |
| `GET /organizations/{uuid}` | `organizations.retrieve` |
| `GET /outgoing_communications` | `outgoing_communications.list` / `list_all` |
| `GET /sample_webhook_data` | `webhooks.sample` |

## Changes

| File | Change |
|------|--------|
| `lib/calendlyr.rb` | 6 new autoloads (2 resources, 4 objects) |
| `lib/calendlyr/version.rb` | `0.10.0` → `1.0.0` |
| `lib/calendlyr/resources/event_types.rb` | `list_available_times`, `list_memberships`, `list_all_memberships` |
| `lib/calendlyr/resources/organizations.rb` | `retrieve(uuid:)` |
| `lib/calendlyr/resources/webhooks.rb` | `sample(event:, organization:, scope:)` |
| `lib/calendlyr/resources/scheduling_links.rb` | New resource |
| `lib/calendlyr/resources/outgoing_communications.rb` | New resource |
| `lib/calendlyr/objects/event_types/available_time.rb` | New object |
| `lib/calendlyr/objects/event_types/membership.rb` | New object |
| `lib/calendlyr/objects/scheduling_link.rb` | New object |
| `lib/calendlyr/objects/outgoing_communication.rb` | New object |
| `CHANGELOG.md` | Added [1.0.0] section |
| `test/**` | Tests + fixtures for all new endpoints |